### PR TITLE
design(phase-4): slice design docs for slices 9, 10, 12, 13, 14

### DIFF
--- a/project-documents/user/slices/011-slice.customer-location.md
+++ b/project-documents/user/slices/011-slice.customer-location.md
@@ -1,0 +1,408 @@
+---
+docType: slice-design
+parent: ../project-guides/003-slices.office-hero.md
+project: office-hero
+dateCreated: 20260524
+status: not_started
+---
+
+# Slice Design 011: Customer & Location management
+
+This is the first core FSM (Field Service Management) feature slice. It implements CRUD for
+`Customer` and `Location` aggregates with a 1:N relationship (a Customer has many service
+Locations). Each Location is geocoded to `lat`/`lng` via a pluggable `GeocodingAdapter`; the
+default v1 implementation calls **Nominatim** (OpenStreetMap free tier, no API key) with an
+**ORS geocoding adapter** as a future swap. Tenant isolation is enforced by PostgreSQL RLS
+per ADR 053; RBAC is enforced via the `@require_role` / `@require_permission` decorators
+established in slice 3. State-changing operations emit audit events via the `AuditService`
+established in slice 4.
+
+It implements **Slice 9** of the master slice plan.
+
+## Goals
+
+* Add dependency to `pyproject.toml`: `httpx` (already present from slice 4 health check; pin
+  `>=0.27`). No new third-party packages required — Nominatim is plain HTTP JSON.
+* Extend `src/office_hero/core/config.py` (created in slice 3):
+  * `NOMINATIM_BASE_URL: str = "https://nominatim.openstreetmap.org"` (configurable)
+  * `NOMINATIM_USER_AGENT: str` (required by Nominatim usage policy; default
+    `"office-hero/0.1 (contact@office-hero.example)"`)
+  * `GEOCODING_ADAPTER: str = "nominatim"` (enum: `"nominatim" | "ors" | "stub"`)
+  * `GEOCODING_TIMEOUT_S: float = 5.0`
+  * `GEOCODING_ALLOWLIST: list[str] = ["nominatim.openstreetmap.org", "api.openrouteservice.org"]`
+    (SSRF defence; only hosts in this list may be called by the geocoder)
+* Create `src/office_hero/adapters/geocoding/__init__.py` (empty).
+* Create `src/office_hero/adapters/geocoding/protocol.py` — `GeocodingAdapter` protocol:
+  * `async def geocode(address: AddressInput) -> Coordinates | None` — returns `Coordinates`
+    (`{lat: float, lng: float, formatted_address: str, source: str}`) or `None` if not resolvable.
+  * `AddressInput` dataclass: `{street, city, state, postal_code, country}`.
+* Create `src/office_hero/adapters/geocoding/nominatim.py` — `NominatimGeocodingAdapter`:
+  * `__init__(base_url, user_agent, timeout, allowlist)` — validates `base_url` host against allowlist
+    on construction.
+  * `async def geocode(address) -> Coordinates | None` — issues `GET {base_url}/search?format=jsonv2&q=...`
+    with the configured `User-Agent` header (per Nominatim ToS).
+  * Returns the first result's `lat`/`lng`; logs `geocoding.nominatim.miss` + returns `None` when no result.
+  * Raises `GeocodingError` (new in `core/exceptions.py`) on HTTP error, timeout, or response parse failure.
+  * Per Nominatim policy: max 1 req/sec — adapter holds an `asyncio.Semaphore(1)` + minimum-interval
+    sleeper. Document this constraint in the docstring.
+* Create `src/office_hero/adapters/geocoding/stub.py` — `StubGeocodingAdapter` for tests:
+  * Deterministic: returns `{lat: 40.0 + hash(street) % 100 / 100, lng: -75.0 + ..., source: "stub"}`
+    so test assertions can pin exact coordinates.
+* Create `src/office_hero/adapters/geocoding/ors.py` — `ORSGeocodingAdapter` (skeleton, deferred):
+  * Class exists but raises `NotImplementedError` from `geocode()`; documented as "enabled in
+    Slice 13 follow-up when ORS API key is provisioned". Wired into the factory below so the
+    config switch is testable.
+* Create `src/office_hero/adapters/geocoding/factory.py` — `build_geocoding_adapter(settings) ->
+  GeocodingAdapter` selecting concrete adapter based on `settings.GEOCODING_ADAPTER`. Returns
+  the `StubGeocodingAdapter` under `pytest` (detected via `os.environ.get("PYTEST_CURRENT_TEST")`)
+  unless overridden by config — keeps unit tests off the live network by default.
+* Extend `src/office_hero/core/exceptions.py`:
+  * `class GeocodingError(Exception)` — raised by adapter on network/parse failures.
+  * `class CustomerNotFoundError(Exception)` — raised by service when ID unknown / cross-tenant.
+  * `class LocationNotFoundError(Exception)` — same for locations.
+* Create `src/office_hero/models/customer.py` — SQLAlchemy ORM model `Customer`:
+  * `id: Mapped[UUID]` (PK, `default=uuid4`)
+  * `tenant_id: Mapped[UUID]` (FK `tenants.id`, NOT NULL — RLS pivot)
+  * `name: Mapped[str]` (255, NOT NULL)
+  * `email: Mapped[str | None]` (255, nullable; CITEXT in migration)
+  * `phone: Mapped[str | None]` (50, nullable)
+  * `notes: Mapped[str | None]` (Text, nullable)
+  * `archived: Mapped[bool]` (default False — soft delete)
+  * `external_id: Mapped[str | None]` (255, nullable — back-office adapter link; ADR 056)
+  * `created_at`, `updated_at` (TIMESTAMPTZ, server defaults)
+  * `__table_args__`: unique `(tenant_id, lower(email))` partial index where email is not null;
+    GIN trigram index on `name` for search (created in migration via raw SQL).
+  * `locations: Mapped[list["Location"]] = relationship(back_populates="customer", cascade="all, delete-orphan")`
+* Create `src/office_hero/models/location.py` — SQLAlchemy ORM model `Location`:
+  * `id`, `tenant_id`, `customer_id` (FK `customers.id`, NOT NULL)
+  * `label: Mapped[str | None]` (255 — e.g. "Main Office", "Warehouse #2")
+  * `street: Mapped[str]` (255, NOT NULL)
+  * `street2: Mapped[str | None]` (255)
+  * `city: Mapped[str]` (120, NOT NULL)
+  * `state: Mapped[str]` (60, NOT NULL — US state code or province)
+  * `postal_code: Mapped[str]` (20, NOT NULL)
+  * `country: Mapped[str]` (2, NOT NULL, default `"US"` — ISO 3166-1 alpha-2)
+  * `lat: Mapped[float | None]` (Numeric(9,6))
+  * `lng: Mapped[float | None]` (Numeric(9,6))
+  * `geocode_source: Mapped[str | None]` (50 — `"nominatim" | "ors" | "manual" | "stub"`)
+  * `geocode_status: Mapped[str]` (20, default `"pending"` — `"pending" | "ok" | "failed" | "manual"`)
+  * `geocoded_at: Mapped[datetime | None]`
+  * `archived: Mapped[bool]` (default False)
+  * `created_at`, `updated_at`
+  * `customer: Mapped["Customer"] = relationship(back_populates="locations")`
+  * `__table_args__`: index on `(tenant_id, customer_id)`; index on `(tenant_id, geocode_status)`
+    so the geocoding worker can find `pending` rows quickly.
+* Update `src/office_hero/models/__init__.py` to import `Customer` and `Location` so they
+  register with `Base.metadata`.
+* Create `src/office_hero/repositories/customer_repository.py`:
+  * `CustomerRepository` (concrete) and `CustomerRepositoryProtocol` (ABC) per repo-pattern.
+  * Methods (all `async`):
+    * `create(tenant_id, name, email, phone, notes, external_id=None) -> Customer`
+    * `get_by_id(customer_id, tenant_id) -> Customer | None` (tenant check is defence-in-depth on
+      top of RLS; never trust the JWT-extracted tenant_id alone — re-verify on the row)
+    * `list(tenant_id, *, search: str | None, archived: bool = False, limit: int = 50,
+      offset: int = 0) -> tuple[list[Customer], int]` (returns rows + total count for pagination;
+      uses `ILIKE` on name + email; total via `SELECT COUNT(*)`)
+    * `update(customer_id, tenant_id, **patch) -> Customer` (raises `CustomerNotFoundError` on miss)
+    * `archive(customer_id, tenant_id) -> Customer` (sets `archived=True`; soft delete)
+    * `restore(customer_id, tenant_id) -> Customer` (clears `archived`)
+* Create `src/office_hero/repositories/location_repository.py`:
+  * `LocationRepository` + `LocationRepositoryProtocol`.
+  * Methods:
+    * `create(tenant_id, customer_id, *, street, street2, city, state, postal_code, country, label)
+      -> Location`
+    * `get_by_id(location_id, tenant_id) -> Location | None`
+    * `list_for_customer(customer_id, tenant_id, *, archived: bool = False) -> list[Location]`
+    * `list_pending_geocode(tenant_id, limit: int = 50) -> list[Location]` (worker hook)
+    * `update(location_id, tenant_id, **patch) -> Location`
+    * `set_coordinates(location_id, tenant_id, lat, lng, source) -> Location`
+      (sets `lat`, `lng`, `geocode_source`, `geocode_status="ok"`, `geocoded_at=now()`)
+    * `mark_geocode_failed(location_id, tenant_id, error: str) -> Location`
+      (sets `geocode_status="failed"`)
+    * `archive(location_id, tenant_id) -> Location`
+* Create `src/office_hero/repositories/mocks.py` additions (or `tests/mocks/...`):
+  * `InMemoryCustomerRepository`, `InMemoryLocationRepository` honouring the protocols, used in
+    unit tests for the service layer.
+* Create `src/office_hero/services/customer_service.py`:
+  * `class CustomerService`:
+    * `__init__(repo: CustomerRepositoryProtocol, audit: AuditService)`
+    * `async def create(tenant_id, user_id, *, name, email, phone, notes) -> Customer` — calls
+      `repo.create`, emits audit `customer.created`, returns customer.
+    * `async def update(tenant_id, user_id, customer_id, patch) -> Customer` — re-fetches to
+      enforce tenant scope, computes diff for audit `customer.updated`.
+    * `async def archive(tenant_id, user_id, customer_id) -> Customer` — audit `customer.archived`.
+    * `async def restore(...)` — audit `customer.restored`.
+    * `async def get(tenant_id, customer_id) -> Customer` — raises `CustomerNotFoundError`.
+    * `async def list(tenant_id, *, search, archived, limit, offset) -> tuple[list[Customer], int]`.
+  * Audit `details` payload must NEVER contain raw PII unless necessary; for now persist the diff
+    (changed field names + before/after) but redact `notes` (free-text) when length > 256 chars.
+* Create `src/office_hero/services/location_service.py`:
+  * `class LocationService`:
+    * `__init__(repo: LocationRepositoryProtocol, customer_repo, audit, geocoder)`.
+    * `async def create(tenant_id, user_id, customer_id, address_fields, label, *,
+      geocode: bool = True) -> Location`:
+      * Verify customer exists (cross-tenant safety).
+      * Insert row with `geocode_status="pending"`.
+      * If `geocode=True`, call `geocoder.geocode(address)` synchronously; on success call
+        `set_coordinates`, on failure call `mark_geocode_failed`. Both paths emit audit
+        `location.created` (with `geocode_status` field).
+      * If `geocode=False`, just emit `location.created` with status pending.
+    * `async def update(tenant_id, user_id, location_id, patch, *, regeocode: bool = "auto")`:
+      * `regeocode="auto"` re-geocodes when any address field changes; `regeocode=True` always;
+        `regeocode=False` never.
+      * Emits `location.updated` with diff.
+    * `async def manual_set_coordinates(tenant_id, user_id, location_id, lat, lng) -> Location`
+      — Dispatcher override; sets `geocode_source="manual"`, `geocode_status="manual"`. Emits
+      `location.coordinates_set_manual` audit event.
+    * `async def archive(...)`, `async def get(...)`, `async def list_for_customer(...)`.
+* Create `src/office_hero/api/schemas/customer.py` — Pydantic v2 request/response schemas with
+  `model_config = ConfigDict(extra="forbid")` (per HLD §Security A03):
+  * `CustomerCreate` — `{name, email?, phone?, notes?}`. `name` min 1 / max 255.
+  * `CustomerUpdate` — same fields, all optional. At least one must be set (model validator).
+  * `CustomerRead` — full read view, `id`, `tenant_id`, `name`, `email`, `phone`, `notes`,
+    `archived`, `external_id`, `created_at`, `updated_at`, embedded `locations: list[LocationRead]`
+    only on detail endpoint (`include_locations=True`).
+  * `CustomerList` — `{items: list[CustomerSummary], total: int, limit: int, offset: int}`.
+  * `CustomerSummary` — id, name, location_count, primary_city (cheap projection).
+* Create `src/office_hero/api/schemas/location.py`:
+  * `LocationCreate` — `{customer_id: UUID, label?, street, street2?, city, state, postal_code,
+    country (default "US"), geocode: bool = True}`.
+  * `LocationUpdate` — all optional plus `regeocode: bool | "auto" = "auto"`.
+  * `LocationCoordinatesSet` — `{lat: float (-90..90), lng: float (-180..180)}` (manual override).
+  * `LocationRead` — full view including `lat`, `lng`, `geocode_status`, `geocode_source`.
+* Create `src/office_hero/api/routes/customers.py` — `prefix="/customers"`, `tags=["customers"]`:
+  * `POST /customers` — `@require_permission("customers:write")`; rate-limit `write` tier
+    (60 req/min per slice 4 defaults).
+  * `GET /customers` — `@require_permission("customers:read")`; query params `search`, `archived`,
+    `limit (max 200)`, `offset`.
+  * `GET /customers/{id}` — `@require_permission("customers:read")`; returns embedded locations.
+  * `PATCH /customers/{id}` — `@require_permission("customers:write")`.
+  * `POST /customers/{id}/archive` — `@require_role([TenantAdmin, Operator, OperatorStaff])`
+    (archive is destructive-ish; restrict to admins).
+  * `POST /customers/{id}/restore` — same role gate as archive.
+* Create `src/office_hero/api/routes/locations.py` — `prefix=""`, `tags=["locations"]`:
+  * `POST /customers/{customer_id}/locations` — `@require_permission("customers:write")`.
+  * `GET /customers/{customer_id}/locations` — `@require_permission("customers:read")`.
+  * `GET /locations/{id}` — `@require_permission("customers:read")`.
+  * `PATCH /locations/{id}` — `@require_permission("customers:write")`.
+  * `POST /locations/{id}/coordinates` — `@require_role([Dispatcher, TenantAdmin, Operator])` for
+    manual override.
+  * `POST /locations/{id}/regeocode` — `@require_role([Dispatcher, TenantAdmin, Operator])` to
+    force re-geocoding (e.g. after correcting an address). Rate-limit at 5 req/min/user to
+    protect the Nominatim quota.
+  * `POST /locations/{id}/archive` — `@require_role([TenantAdmin, Operator, OperatorStaff])`.
+* Register both routers in `src/office_hero/api/app.py`.
+* Wire dependency providers in `src/office_hero/api/state.py`:
+  * `get_customer_service() -> CustomerService`
+  * `get_location_service() -> LocationService`
+  * `get_geocoding_adapter() -> GeocodingAdapter` (built from settings).
+* Create migration `alembic/versions/0004_customers_and_locations.py`:
+  * Enable `CITEXT` extension if not already present (`CREATE EXTENSION IF NOT EXISTS citext;`).
+  * Enable `pg_trgm` extension for trigram search.
+  * Create `customers` table; columns per model above; `tenant_id` FK to `tenants(id)`.
+  * Create unique partial index `uq_customer_tenant_email_active`
+    ON `customers (tenant_id, lower(email))` WHERE `email IS NOT NULL AND archived = false`.
+  * Create trigram GIN index `idx_customer_name_trgm`
+    ON `customers USING GIN (name gin_trgm_ops)`.
+  * `ALTER TABLE customers ENABLE ROW LEVEL SECURITY;`
+  * `CREATE POLICY customer_tenant_isolation ON customers
+       USING (tenant_id = current_setting('app.tenant_id')::uuid);`
+  * Create `locations` table; FK to `customers(id) ON DELETE CASCADE`, FK to `tenants(id)`.
+  * Index `idx_location_tenant_customer` ON `locations (tenant_id, customer_id)`.
+  * Index `idx_location_tenant_status` ON `locations (tenant_id, geocode_status)`.
+  * `ALTER TABLE locations ENABLE ROW LEVEL SECURITY;`
+  * `CREATE POLICY location_tenant_isolation ON locations
+       USING (tenant_id = current_setting('app.tenant_id')::uuid);`
+  * Downgrade drops policies, indexes, tables in reverse order.
+* Create unit tests in `tests/unit/`:
+  * `tests/unit/test_customer_service.py`:
+    * `test_create_customer_emits_audit_event`
+    * `test_create_customer_rejects_duplicate_email_same_tenant`
+    * `test_update_customer_redacts_long_notes_in_audit`
+    * `test_archive_customer_sets_flag_and_audit`
+    * `test_get_customer_cross_tenant_returns_not_found` (defence-in-depth, simulates RLS-bypass attempt)
+    * `test_list_customer_search_matches_name_substring`
+  * `tests/unit/test_location_service.py`:
+    * `test_create_location_calls_geocoder_and_sets_coordinates`
+    * `test_create_location_geocoder_failure_marks_failed_but_still_returns_location`
+    * `test_create_location_geocode_false_skips_geocoder`
+    * `test_update_location_address_auto_regeocodes`
+    * `test_update_location_label_only_does_not_regeocode`
+    * `test_manual_set_coordinates_overrides_geocoder_status`
+    * `test_create_location_unknown_customer_raises`
+    * `test_create_location_other_tenant_customer_raises_not_found`
+  * `tests/unit/test_nominatim_adapter.py`:
+    * `test_nominatim_returns_coordinates_on_match` (httpx mock)
+    * `test_nominatim_returns_none_on_no_match`
+    * `test_nominatim_rate_limit_one_per_second` (asserts second call waits ≥1s)
+    * `test_nominatim_rejects_host_outside_allowlist` (SSRF)
+    * `test_nominatim_timeout_raises_geocoding_error`
+    * `test_nominatim_sends_user_agent_header` (Nominatim ToS)
+* Create API tests in `tests/api/test_customers_api.py`:
+  * `test_post_customer_requires_jwt` (401)
+  * `test_post_customer_wrong_permission_403` (Sales role without `customers:write`)
+  * `test_post_customer_201_and_returns_id`
+  * `test_get_customer_cross_tenant_returns_404` (tenant A cannot see tenant B's customer)
+  * `test_list_customers_pagination`
+  * `test_list_customers_search`
+  * `test_archive_then_restore_roundtrip`
+  * `test_create_customer_rate_limit_60_per_min` (61st write returns 429)
+* Create API tests in `tests/api/test_locations_api.py`:
+  * `test_post_location_geocodes_and_returns_lat_lng` (using stub adapter)
+  * `test_post_location_geocode_failure_still_returns_201_with_status_failed`
+  * `test_get_locations_for_customer_other_tenant_404`
+  * `test_manual_coordinates_requires_dispatcher_or_admin` (Technician 403)
+  * `test_regeocode_endpoint_rate_limited_5_per_min`
+  * `test_patch_location_address_triggers_regeocode`
+* Integration test `tests/integration/test_customer_location_rls.py` (Neon branch):
+  * `test_tenant_a_cannot_select_tenant_b_customer_via_rls` — set
+    `app.tenant_id = tenantB_id`; `SELECT * FROM customers WHERE id = tenantA_customer_id`
+    returns 0 rows (RLS hides the row, not 403 — silent isolation).
+  * `test_cascade_delete_locations_when_customer_hard_deleted` (admin-only escape hatch, if/when
+    a hard delete is exposed in a later slice).
+
+## Structure
+
+```text
+src/office_hero/
+├── adapters/
+│   └── geocoding/
+│       ├── __init__.py
+│       ├── protocol.py        # GeocodingAdapter Protocol + AddressInput, Coordinates
+│       ├── nominatim.py       # NominatimGeocodingAdapter (default)
+│       ├── ors.py             # ORSGeocodingAdapter (stubbed, future)
+│       ├── stub.py            # StubGeocodingAdapter (deterministic, tests)
+│       └── factory.py         # build_geocoding_adapter(settings)
+├── models/
+│   ├── customer.py            # Customer ORM model
+│   └── location.py            # Location ORM model
+├── repositories/
+│   ├── customer_repository.py
+│   └── location_repository.py
+├── services/
+│   ├── customer_service.py
+│   └── location_service.py
+├── api/
+│   ├── schemas/
+│   │   ├── customer.py
+│   │   └── location.py
+│   └── routes/
+│       ├── customers.py
+│       └── locations.py
+└── core/
+    └── exceptions.py          # +GeocodingError, +CustomerNotFoundError, +LocationNotFoundError
+
+alembic/
+└── versions/
+    └── 0004_customers_and_locations.py
+
+tests/
+├── unit/
+│   ├── test_customer_service.py
+│   ├── test_location_service.py
+│   └── test_nominatim_adapter.py
+├── api/
+│   ├── test_customers_api.py
+│   └── test_locations_api.py
+└── integration/
+    └── test_customer_location_rls.py
+```
+
+## Failing Test Outline
+
+```python
+# tests/unit/test_location_service.py
+import pytest
+from uuid import uuid4
+from office_hero.services.location_service import LocationService
+from office_hero.adapters.geocoding.stub import StubGeocodingAdapter
+
+
+@pytest.mark.asyncio
+async def test_create_location_calls_geocoder_and_sets_coordinates(
+    location_repo, customer_repo, audit_service
+):
+    """LocationService.create geocodes the address and persists lat/lng."""
+    svc = LocationService(location_repo, customer_repo, audit_service, StubGeocodingAdapter())
+    cust = await customer_repo.create(tenant_id=TENANT_A, name="Acme Plumbing", ...)
+    loc = await svc.create(
+        tenant_id=TENANT_A, user_id=USER_A, customer_id=cust.id,
+        address_fields={"street": "123 Main St", "city": "Philadelphia",
+                        "state": "PA", "postal_code": "19103", "country": "US"},
+        label="Main Office",
+    )
+    assert loc.lat is not None and loc.lng is not None
+    assert loc.geocode_status == "ok"
+    assert loc.geocode_source == "stub"
+    assert any(e.event_type == "location.created" for e in audit_service.events)
+
+
+@pytest.mark.asyncio
+async def test_create_location_other_tenant_customer_raises(
+    location_repo, customer_repo, audit_service
+):
+    """Creating a location for a customer in another tenant raises CustomerNotFoundError."""
+    svc = LocationService(location_repo, customer_repo, audit_service, StubGeocodingAdapter())
+    cust = await customer_repo.create(tenant_id=TENANT_A, name="Acme", ...)
+    with pytest.raises(CustomerNotFoundError):
+        await svc.create(
+            tenant_id=TENANT_B, user_id=USER_B, customer_id=cust.id,
+            address_fields={...}, label="x",
+        )
+
+
+# tests/api/test_customers_api.py
+def test_get_customer_cross_tenant_returns_404(client, tenant_a_token, tenant_b_customer_id):
+    """Tenant A cannot see Tenant B's customer; RLS hides → 404 (not 403)."""
+    resp = client.get(
+        f"/customers/{tenant_b_customer_id}",
+        headers={"Authorization": f"Bearer {tenant_a_token}"},
+    )
+    assert resp.status_code == 404
+```
+
+## Dependencies
+
+* **Slice 2 (Database foundation)** — async engine, `get_session`, RLS helper, Alembic env.
+* **Slice 3 (Auth & RBAC)** — JWT middleware, `@require_role` / `@require_permission`, `Role` enum,
+  `tenant_id` request state.
+* **Slice 4 (Observability)** — `AuditService`, structured logging, security headers, slowapi
+  limiter (write tier defaults).
+* **Slice 7 (Tenant management)** — `tenants` table + provisioning (required for FK on
+  `customers.tenant_id`).
+* Relevant ADRs: **053** (RLS), **058** (SQLAlchemy 2.x), **059** (PostgreSQL JSONB / CITEXT /
+  pg_trgm), **060** (RBAC), **062** (rate limiting tiers), **063** (audit events).
+
+## Effort
+
+Estimate: **2/5**. Two tables, one adapter family, two services, two routers. The geocoding
+adapter is the only externally-coupled component; everything else is canonical CRUD over RLS.
+The main effort is comprehensive TDD coverage (≈14 unit + 14 API tests) and getting the
+Nominatim rate-limit semaphore correct so we never trip their ToS in CI. The migration is
+slightly non-trivial because of `citext` and `pg_trgm` extension handling.
+
+## Risk Callouts
+
+* **Nominatim usage policy.** 1 req/sec hard ceiling and a *real* `User-Agent` are required;
+  Nominatim aggressively blocks abusive clients. The adapter enforces both, and tests assert
+  the rate-limit sleeper. **Mitigation:** stub adapter is the default in CI; live calls are
+  guarded by `GEOCODING_ADAPTER=nominatim` (off by default in tests).
+* **SSRF risk in geocoder.** Adapter base URL is operator-configurable; allowlist enforcement
+  on construction prevents pointing the geocoder at an internal IP. Tested explicitly.
+* **PII in audit log.** `customer.notes` may contain free-form PII; we truncate long notes in
+  the audit `details` payload. Reviewed against ADR 063.
+* **Email uniqueness.** Scoped per tenant + only enforced when email is non-null and customer
+  is not archived. Confirm with stakeholders that two active customers in the same tenant cannot
+  share an email — if there's a real-world case (e.g. spouses on one billing email), drop the
+  partial-unique index. **OPEN QUESTION** flagged in PR.
+* **Re-geocoding on update.** Auto-regeocode behaviour could create unbounded background work
+  if a power user mass-updates addresses. Rate-limit on the API endpoint (5 req/min) plus
+  audit logging makes this auditable. Bulk import flows in a later slice will need a different
+  pattern (queue-based, separate worker).
+
+---
+
+Once approved, implementation proceeds with the failing unit tests for `CustomerService`,
+then the model + repository + migration, then `LocationService` with the stub geocoder, then
+the Nominatim adapter under TDD, and finally the API routers. The integration test for RLS
+runs against a Neon branch in CI.

--- a/project-documents/user/slices/012-slice.job-management.md
+++ b/project-documents/user/slices/012-slice.job-management.md
@@ -1,0 +1,421 @@
+---
+docType: slice-design
+parent: ../project-guides/003-slices.office-hero.md
+project: office-hero
+dateCreated: 20260524
+status: not_started
+---
+
+# Slice Design 012: Job management (core CRUD)
+
+This slice implements the **Job** aggregate — the operational unit of Office Hero. A Job
+belongs to a `Customer` and a `Location` (from slice 11), carries industry-specific
+`custom_fields` in a JSONB column validated against per-industry templates, and has a strict
+status lifecycle enforced by the service layer. Illegal transitions return **422 Unprocessable
+Entity**; every state-changing operation emits an audit event via `AuditService`.
+
+This slice deliberately scopes to CRUD + state transitions. **Routing** (Slice 13) and
+**Dispatch** (Slice 14) consume the Job model created here; **Contracts** (Slice 11 of the
+master plan, design doc not in this batch) generate Jobs from recurring schedules later.
+
+It implements **Slice 10** of the master slice plan.
+
+## Job Status Lifecycle
+
+```text
+                   ┌──────────┐
+       create →    │ pending  │ ──── cancel ───────┐
+                   └────┬─────┘                    │
+                        │ schedule                 │
+                        ▼                          │
+                   ┌──────────┐                    │
+                   │scheduled │ ──── cancel ───────┤
+                   └────┬─────┘                    │
+                        │ start                    │
+                        ▼                          │
+                   ┌──────────────┐                │
+                   │ in_progress  │ ─── cancel ────┤
+                   └────┬─────────┘                │
+                        │ complete                 │
+                        ▼                          ▼
+                   ┌──────────┐              ┌──────────┐
+                   │ complete │              │cancelled │
+                   └──────────┘              └──────────┘
+```
+
+* Allowed transitions are encoded in a `JobTransition` table (Python dict, not DB):
+  `{("pending", "scheduled"), ("pending", "cancelled"), ("scheduled", "in_progress"),
+  ("scheduled", "cancelled"), ("in_progress", "complete"), ("in_progress", "cancelled")}`.
+* Any other transition raises `InvalidJobTransitionError` → HTTP 422.
+* `complete` and `cancelled` are terminal — no transitions out.
+* Re-opening a completed/cancelled Job is **out of scope for this slice**; ticket as future work.
+
+## Goals
+
+* Extend `src/office_hero/core/exceptions.py`:
+  * `class JobNotFoundError(Exception)`
+  * `class InvalidJobTransitionError(Exception)` — carries `from_status` and `to_status`.
+  * `class CustomFieldValidationError(Exception)` — carries `field_name`, `errors: list[str]`.
+* Create `src/office_hero/core/job_status.py` — `JobStatus` enum (`StrEnum`):
+  * `PENDING = "pending"`, `SCHEDULED = "scheduled"`, `IN_PROGRESS = "in_progress"`,
+    `COMPLETE = "complete"`, `CANCELLED = "cancelled"`.
+  * Module-level constant `ALLOWED_TRANSITIONS: frozenset[tuple[JobStatus, JobStatus]]` as above.
+  * Helper `def can_transition(current: JobStatus, target: JobStatus) -> bool`.
+  * Helper `def is_terminal(status: JobStatus) -> bool`.
+* Create `src/office_hero/core/industry.py` — `Industry` enum:
+  * `PLUMBING = "plumbing"`, `HVAC = "hvac"`, `PEST_CONTROL = "pest_control"`,
+    `GENERIC = "generic"` (default fallback when Tenant has no industry configured).
+* Create `src/office_hero/services/custom_field_templates/__init__.py` — pluggable templates:
+  * `class CustomFieldTemplate(Protocol)`:
+    * `industry: Industry` (class attribute)
+    * `def validate(custom_fields: dict) -> dict` — returns canonicalised dict; raises
+      `CustomFieldValidationError` on schema violations.
+  * **Phase 4 scope:** define the protocol and ship empty/`pass-through` template implementations
+    for each industry. The actual validation rules are Phase 6 implementation detail per the
+    Phase 4 charter; we register the seams so Phase 6 only adds rule code, never plumbing.
+* Create `src/office_hero/services/custom_field_templates/plumbing.py`:
+  * `class PlumbingTemplate`: `industry = Industry.PLUMBING`; `validate()` currently allows any
+    dict with string keys; future rule examples documented as comments (`{"fixture_type":
+    "toilet|sink|tub|water_heater", "warranty_months": int}`).
+* Create `src/office_hero/services/custom_field_templates/hvac.py` — same pattern; sample fields
+  in comments (`{"unit_model": str, "refrigerant_lbs": float, "filter_size": str}`).
+* Create `src/office_hero/services/custom_field_templates/pest_control.py` — same pattern;
+  comments (`{"pest_type": "termite|rodent|ant|...", "chemical_used": str,
+  "epa_registration_number": str}`).
+* Create `src/office_hero/services/custom_field_templates/generic.py` — accepts any keys.
+* Create `src/office_hero/services/custom_field_templates/registry.py` — `dict[Industry,
+  CustomFieldTemplate]`; `def get_template(industry: Industry) -> CustomFieldTemplate`.
+* Create `src/office_hero/models/job.py` — SQLAlchemy ORM model `Job`:
+  * `id: Mapped[UUID]` (PK)
+  * `tenant_id: Mapped[UUID]` (FK `tenants.id`, NOT NULL — RLS pivot)
+  * `customer_id: Mapped[UUID]` (FK `customers.id`, NOT NULL)
+  * `location_id: Mapped[UUID]` (FK `locations.id`, NOT NULL)
+  * `industry: Mapped[str]` (50, NOT NULL — copies `tenant.industry` at create time so historical
+    Jobs aren't broken by tenant industry changes)
+  * `title: Mapped[str]` (255, NOT NULL — short description, used in dispatch UI lists)
+  * `description: Mapped[str | None]` (Text)
+  * `status: Mapped[str]` (20, NOT NULL, default `"pending"`)
+  * `priority: Mapped[int]` (NOT NULL, default 50 — 0=highest, 100=lowest; used by routing
+    ranking in slice 13)
+  * `service_type: Mapped[str | None]` (120 — e.g. "leak_repair", "inspection";
+    free-text v1, controlled list v2)
+  * `requested_at: Mapped[datetime | None]` (TIMESTAMPTZ — customer's preferred window start)
+  * `requested_until: Mapped[datetime | None]` (TIMESTAMPTZ — customer's preferred window end)
+  * `estimated_duration_min: Mapped[int]` (NOT NULL, default 60 — used by routing)
+  * `scheduled_for: Mapped[datetime | None]` (set when status moves to scheduled)
+  * `started_at: Mapped[datetime | None]` (set when status moves to in_progress)
+  * `completed_at: Mapped[datetime | None]`
+  * `cancelled_at: Mapped[datetime | None]`
+  * `cancel_reason: Mapped[str | None]` (Text — required when cancelling, see service)
+  * `custom_fields: Mapped[dict] = mapped_column(JSONB, nullable=False, server_default="{}")`
+  * `external_id: Mapped[str | None]` (255 — back-office link per ADR 056)
+  * `created_by_user_id: Mapped[UUID]` (FK `users.id`)
+  * `created_at`, `updated_at` (TIMESTAMPTZ)
+  * `customer: Mapped["Customer"] = relationship()`
+  * `location: Mapped["Location"] = relationship()`
+  * `__table_args__`:
+    * Index `(tenant_id, status)` — dispatch dashboard filters by status.
+    * Index `(tenant_id, scheduled_for)` — daily view + routing.
+    * Index `(tenant_id, customer_id)` — customer detail view.
+    * GIN index on `custom_fields` (`USING gin (custom_fields jsonb_path_ops)`) — future
+      Tenant-side queries on industry fields.
+* Update `src/office_hero/models/__init__.py` to import `Job`.
+* Update `Tenant` model (in `models/tenant.py`) — add `industry: Mapped[str]` (50, NOT NULL,
+  default `"generic"`) via migration. Note: stakeholders may prefer industry as a separate
+  enum table for multi-industry tenants; **OPEN QUESTION** flagged in PR (treated as a single
+  default industry per tenant for v1).
+* Create `src/office_hero/repositories/job_repository.py`:
+  * `JobRepository` + `JobRepositoryProtocol`.
+  * Methods (all `async`):
+    * `create(tenant_id, *, customer_id, location_id, industry, title, description,
+      priority, service_type, requested_at, requested_until, estimated_duration_min,
+      custom_fields, created_by_user_id) -> Job`
+    * `get_by_id(job_id, tenant_id) -> Job | None`
+    * `list(tenant_id, *, status: list[str] | None, customer_id: UUID | None,
+      scheduled_for_date: date | None, search: str | None, limit: int = 50,
+      offset: int = 0) -> tuple[list[Job], int]`
+    * `update_fields(job_id, tenant_id, **patch) -> Job` — partial field update; does NOT
+      change status (status changes go through `update_status`).
+    * `update_status(job_id, tenant_id, new_status, *, scheduled_for=None, started_at=None,
+      completed_at=None, cancelled_at=None, cancel_reason=None) -> Job` — sets the lifecycle
+      timestamp matching `new_status` atomically.
+    * `list_due_for_routing(tenant_id, date) -> list[Job]` — status in
+      `("pending", "scheduled")` and `scheduled_for::date = date` OR `requested_at::date = date`.
+      (consumed by Slice 13 routing.)
+* Create `src/office_hero/services/job_service.py`:
+  * `class JobService`:
+    * `__init__(repo: JobRepositoryProtocol, customer_repo, location_repo, audit: AuditService,
+      template_registry)`.
+    * `async def create(tenant_id, user_id, payload: JobCreate) -> Job`:
+      * Verify `customer_id` belongs to tenant via `customer_repo.get_by_id`.
+      * Verify `location_id` belongs to same customer (defence-in-depth).
+      * Look up tenant's industry; copy onto Job row.
+      * Validate `custom_fields` against `template_registry[industry].validate(...)`.
+      * Persist with `status="pending"`, `created_by_user_id=user_id`.
+      * Emit audit `job.created` with `{job_id, customer_id, location_id, industry, priority,
+        title}`.
+    * `async def update(tenant_id, user_id, job_id, patch: JobUpdate) -> Job`:
+      * Disallow patching `status` here — status uses dedicated endpoints.
+      * Disallow patching `tenant_id`, `customer_id`, `industry`, `created_by_user_id` (immutable).
+      * If `custom_fields` present, re-validate via the template for the Job's industry.
+      * If `location_id` changes, verify new location belongs to same customer.
+      * Compute diff for audit `job.updated`.
+    * `async def schedule(tenant_id, user_id, job_id, scheduled_for: datetime) -> Job`:
+      * Verifies current status is `pending` (the only legal source for `scheduled`).
+      * Calls `repo.update_status(..., new_status="scheduled", scheduled_for=scheduled_for)`.
+      * Emits `job.scheduled` audit with `{from: "pending", to: "scheduled", scheduled_for}`.
+      * Note: dispatch (Slice 14) is the more usual way to enter `scheduled` because dispatch
+        creates the Route and pegs the Job to it. This bare `schedule()` method exists for
+        manual non-dispatched scheduling (e.g. "we have an appointment, no specific vehicle yet").
+    * `async def start(tenant_id, user_id, job_id) -> Job` — transition `scheduled → in_progress`.
+      Sets `started_at = now()`. Emits `job.started`. (Technician-callable; commonly via mobile.)
+    * `async def complete(tenant_id, user_id, job_id, *, completion_notes: str | None) -> Job`
+      — transition `in_progress → complete`. Sets `completed_at = now()`. Audit `job.completed`
+      with completion_notes truncated to 1024 chars.
+    * `async def cancel(tenant_id, user_id, job_id, *, reason: str) -> Job`:
+      * Transition any non-terminal status → `cancelled`. `reason` is required (min length 3).
+      * Sets `cancelled_at = now()`, `cancel_reason = reason`.
+      * Audit `job.cancelled` with `{from_status, reason}`.
+    * `async def get(tenant_id, job_id) -> Job` — raises `JobNotFoundError`.
+    * `async def list(tenant_id, *, filters, pagination) -> tuple[list[Job], int]`.
+  * Each transition method internally calls a private `_transition(job, target)` that uses
+    `can_transition()` from `core/job_status.py` and raises `InvalidJobTransitionError`
+    (mapped to **422** by the global exception handler) when illegal.
+* Create `src/office_hero/api/schemas/job.py`:
+  * `JobCreate`:
+    * `customer_id: UUID`, `location_id: UUID`
+    * `title: str` (1..255)
+    * `description: str | None` (0..10_000)
+    * `priority: int = 50` (0..100)
+    * `service_type: str | None` (0..120)
+    * `requested_at: datetime | None`, `requested_until: datetime | None`
+    * `estimated_duration_min: int = 60` (5..1440)
+    * `custom_fields: dict = {}` — `dict[str, Any]`; deep validation happens in service.
+    * `model_config = ConfigDict(extra="forbid")`.
+  * `JobUpdate` — all of the above optional except `customer_id`, `industry` not patchable.
+    Model validator: at least one field set.
+  * `JobScheduleRequest` — `{scheduled_for: datetime}`.
+  * `JobCompleteRequest` — `{completion_notes: str | None}` (≤1024 chars).
+  * `JobCancelRequest` — `{reason: str}` (3..512).
+  * `JobRead` — full DTO; embeds `customer: CustomerSummary` and `location: LocationRead`
+    on detail.
+  * `JobList` — `{items: list[JobSummary], total, limit, offset}`.
+  * `JobSummary` — `id`, `title`, `status`, `priority`, `scheduled_for`, `customer_name`,
+    `location_city`.
+* Create `src/office_hero/api/routes/jobs.py` — `prefix="/jobs"`, `tags=["jobs"]`:
+  * `POST /jobs` — `@require_permission("jobs:write")`. Body `JobCreate`.
+    Rate-limited at `write` tier (60 req/min).
+  * `GET /jobs` — `@require_permission("jobs:read")`. Query: `status` (multi-select), `customer_id`,
+    `scheduled_for_date` (ISO date), `search`, `limit (max 200)`, `offset`.
+  * `GET /jobs/{id}` — `@require_permission("jobs:read")`.
+  * `PATCH /jobs/{id}` — `@require_permission("jobs:write")`.
+  * `POST /jobs/{id}/schedule` — `@require_permission("jobs:dispatch")` (Dispatcher, TenantAdmin,
+    Operator). Body `JobScheduleRequest`.
+  * `POST /jobs/{id}/start` — `@require_role([Technician, TechnicianHelper, Dispatcher,
+    TenantAdmin, Operator, OperatorStaff])`. (Most often called from mobile.)
+  * `POST /jobs/{id}/complete` — same role set as `/start`. Body `JobCompleteRequest`.
+  * `POST /jobs/{id}/cancel` — `@require_permission("jobs:cancel")` (Dispatcher, TenantAdmin,
+    Operator).
+* Update `src/office_hero/api/state.py` — `get_job_service() -> JobService`.
+* Register the jobs router in `src/office_hero/api/app.py`.
+* Update `src/office_hero/api/exception_handlers.py` (from slice 4):
+  * Map `InvalidJobTransitionError` → 422 `{detail: "Invalid job status transition", from, to}`.
+  * Map `CustomFieldValidationError` → 422 `{detail, field, errors: [...]}` .
+  * Map `JobNotFoundError` → 404.
+* Create migration `alembic/versions/0005_jobs.py`:
+  * `ALTER TABLE tenants ADD COLUMN industry varchar(50) NOT NULL DEFAULT 'generic';`
+    (back-fill is the default).
+  * Create `jobs` table; columns per model.
+  * Indexes: `(tenant_id, status)`, `(tenant_id, scheduled_for)`, `(tenant_id, customer_id)`.
+  * GIN index: `idx_jobs_custom_fields_gin ON jobs USING gin (custom_fields jsonb_path_ops);`
+  * `ALTER TABLE jobs ENABLE ROW LEVEL SECURITY;`
+  * `CREATE POLICY job_tenant_isolation ON jobs
+       USING (tenant_id = current_setting('app.tenant_id')::uuid);`
+  * CHECK constraints:
+    * `CHECK (status IN ('pending','scheduled','in_progress','complete','cancelled'))`
+    * `CHECK (priority BETWEEN 0 AND 100)`
+    * `CHECK (estimated_duration_min BETWEEN 5 AND 1440)`
+  * Downgrade drops policy, indexes, jobs table, then `industry` column.
+* Create unit tests in `tests/unit/test_job_service.py`:
+  * `test_create_job_with_valid_custom_fields_emits_audit`
+  * `test_create_job_unknown_customer_raises_not_found`
+  * `test_create_job_location_belongs_to_other_customer_raises`
+  * `test_create_job_other_tenant_customer_raises_not_found` (cross-tenant defence-in-depth)
+  * `test_create_job_invalid_custom_fields_raises_422_via_template`
+  * `test_schedule_job_from_pending_succeeds`
+  * `test_schedule_job_from_in_progress_raises_invalid_transition`
+  * `test_start_job_from_scheduled_succeeds_and_sets_started_at`
+  * `test_complete_job_from_in_progress_sets_completed_at_and_audits`
+  * `test_cancel_job_from_any_non_terminal_status_succeeds`
+  * `test_cancel_job_requires_reason_min_3_chars`
+  * `test_cancel_job_from_complete_raises_invalid_transition` (terminal)
+  * `test_cancel_job_from_cancelled_raises_invalid_transition` (terminal)
+  * `test_update_job_status_field_via_patch_is_rejected`
+  * `test_update_job_industry_field_via_patch_is_rejected`
+  * `test_update_job_custom_fields_revalidates_against_template`
+* Unit tests `tests/unit/test_job_status.py`:
+  * `test_can_transition_matrix` — parameterised over the full 5×5 grid; asserts only the
+    documented transitions are allowed.
+  * `test_is_terminal` — complete and cancelled true; others false.
+* Unit tests `tests/unit/test_custom_field_templates.py`:
+  * `test_registry_returns_template_per_industry`
+  * `test_generic_template_accepts_any_dict`
+  * `test_plumbing_template_passes_through_for_now` (Phase 6 will add real rules)
+  * Same for hvac, pest_control.
+* API tests `tests/api/test_jobs_api.py`:
+  * `test_post_job_requires_jwt_401`
+  * `test_post_job_without_jobs_write_perm_403`
+  * `test_post_job_201_and_returns_id`
+  * `test_post_job_invalid_customer_404`
+  * `test_get_job_cross_tenant_404`
+  * `test_list_jobs_filter_by_status_and_date`
+  * `test_list_jobs_pagination`
+  * `test_patch_job_returns_422_when_status_field_supplied`
+  * `test_schedule_job_dispatcher_succeeds`
+  * `test_schedule_job_technician_403` (Technician lacks `jobs:dispatch`)
+  * `test_start_job_technician_succeeds`
+  * `test_complete_job_technician_succeeds_with_notes`
+  * `test_cancel_job_dispatcher_with_reason_succeeds`
+  * `test_cancel_job_without_reason_422`
+  * `test_illegal_status_transition_returns_422`
+  * `test_jobs_write_endpoint_rate_limited_60_per_min`
+* Integration test `tests/integration/test_jobs_rls.py`:
+  * `test_tenant_isolation_jobs_hidden_by_rls` — tenant A jobs are not visible when
+    `app.tenant_id = tenantB`.
+  * `test_custom_fields_jsonb_roundtrip` — write nested JSON, read back, verify shape preserved.
+  * `test_jobs_gin_index_used_for_jsonb_contains_query` — `EXPLAIN ANALYZE` shows
+    Bitmap Index Scan on `idx_jobs_custom_fields_gin` (smoke; not a hard assertion in CI but
+    a debug aid documented in the test).
+
+## Structure
+
+```text
+src/office_hero/
+├── core/
+│   ├── exceptions.py            # +JobNotFoundError, +InvalidJobTransitionError,
+│   │                            #  +CustomFieldValidationError
+│   ├── industry.py              # Industry enum
+│   └── job_status.py            # JobStatus enum + transition matrix + helpers
+├── models/
+│   └── job.py                   # Job ORM model
+├── repositories/
+│   └── job_repository.py
+├── services/
+│   ├── job_service.py
+│   └── custom_field_templates/
+│       ├── __init__.py          # CustomFieldTemplate Protocol
+│       ├── registry.py
+│       ├── generic.py
+│       ├── plumbing.py
+│       ├── hvac.py
+│       └── pest_control.py
+└── api/
+    ├── schemas/
+    │   └── job.py
+    └── routes/
+        └── jobs.py
+
+alembic/
+└── versions/
+    └── 0005_jobs.py             # +industry on tenants; jobs table + RLS + indexes
+
+tests/
+├── unit/
+│   ├── test_job_service.py
+│   ├── test_job_status.py
+│   └── test_custom_field_templates.py
+├── api/
+│   └── test_jobs_api.py
+└── integration/
+    └── test_jobs_rls.py
+```
+
+## Failing Test Outline
+
+```python
+# tests/unit/test_job_service.py
+import pytest
+from office_hero.core.job_status import JobStatus
+from office_hero.core.exceptions import InvalidJobTransitionError
+
+
+@pytest.mark.asyncio
+async def test_cancel_job_from_complete_raises_invalid_transition(job_service, job_in_complete):
+    """A completed Job cannot be cancelled — terminal state."""
+    with pytest.raises(InvalidJobTransitionError) as exc:
+        await job_service.cancel(
+            tenant_id=TENANT_A,
+            user_id=USER_A,
+            job_id=job_in_complete.id,
+            reason="changed my mind",
+        )
+    assert exc.value.from_status == JobStatus.COMPLETE
+    assert exc.value.to_status == JobStatus.CANCELLED
+
+
+# tests/api/test_jobs_api.py
+def test_illegal_status_transition_returns_422(client, dispatcher_token, completed_job_id):
+    """Cancelling a completed job returns 422 with structured error."""
+    resp = client.post(
+        f"/jobs/{completed_job_id}/cancel",
+        json={"reason": "no longer needed"},
+        headers={"Authorization": f"Bearer {dispatcher_token}"},
+    )
+    assert resp.status_code == 422
+    body = resp.json()
+    assert body["from"] == "complete"
+    assert body["to"] == "cancelled"
+```
+
+## Dependencies
+
+* **Slice 2 (Database foundation)** — async engine, RLS helpers, Alembic.
+* **Slice 3 (Auth & RBAC)** — JWT, `@require_role`, `@require_permission`, Role enum.
+* **Slice 4 (Observability)** — `AuditService`, exception handler integration, slowapi.
+* **Slice 7 (Tenant management)** — `tenants` table + the new `industry` column will be added
+  here as the *first* Job slice but a tenant-edit endpoint to change industry is owned by
+  Slice 7's later iteration (out of scope for this slice).
+* **Slice 11 (Customer & Location)** — provides `customers`, `locations`, `customer_repo`,
+  `location_repo`. Job FKs both.
+* Relevant ADRs: **053** (RLS), **056** (back-office Saga is *not* implemented here, but the
+  `external_id` column is reserved for it; `outbox_events` plumbing comes later), **058**, **059**,
+  **060**, **062**, **063**.
+
+## Effort
+
+Estimate: **3/5**. Despite "core CRUD" framing, the slice carries non-trivial design: status
+machine, custom_fields template plumbing, rich relationships to Customer + Location, six
+distinct status endpoints, and ~16 unit + 14 API tests. The migration is moderate (one new
+table + GIN index + check constraints + a column add on `tenants`). The template registry is
+deliberately scaffolded with empty rules so Phase 6 can land industry logic without rewiring.
+
+## Risk Callouts
+
+* **Status machine drift.** Future slices (15 location tracking, 16 dynamic re-routing,
+  17 mobile) will want to mutate status. Centralising `can_transition()` in
+  `core/job_status.py` and forcing every transition through `JobService._transition()`
+  is non-negotiable; reviewers should reject any direct `job.status = ...` outside the service.
+* **JSONB validation surface.** The Phase 4 design leaves rules empty per project charter,
+  but the template seam must be honoured: callers must never bypass `template.validate()`.
+  Add a lint rule or PR-time review check for direct writes to `Job.custom_fields`.
+* **Tenant industry mutation.** If a Tenant changes industry, existing Jobs keep their original
+  industry (copied at create time). New Jobs use the new industry. We do *not* re-validate
+  historical custom_fields. **OPEN QUESTION:** stakeholders may want an explicit
+  "industry migration tool" — out of scope here but worth flagging.
+* **Soft-delete vs cancel semantics.** Cancelling a Job is a status transition, not a soft
+  delete. There is *no* `archived` flag on Jobs in this slice. If listings need to hide
+  cancelled jobs by default, that's a query filter. Confirmed against the master plan: cancelled
+  is a terminal status; no separate archive flag needed.
+* **Performance: GIN index on JSONB.** `jsonb_path_ops` keeps index size sane but only supports
+  `@>` containment queries; an operator who wants `?` key-existence queries needs a second
+  index. Documented as future work.
+* **Audit payload size.** Job description + completion_notes can be large. We truncate
+  completion_notes to 1024 chars in audit payloads; description is referenced by job_id only
+  (audit reader can dereference if needed).
+
+---
+
+Once approved, implementation proceeds with `core/job_status.py` (pure, no deps) and its
+matrix test, then the model + migration, then `JobService` under TDD with the template
+registry stubbed, then the routers. The mobile slices (17 onward) will exercise `start` and
+`complete` end-to-end on hardware.

--- a/project-documents/user/slices/013-slice.vehicle-vehiclecrew.md
+++ b/project-documents/user/slices/013-slice.vehicle-vehiclecrew.md
@@ -1,0 +1,418 @@
+---
+docType: slice-design
+parent: ../project-guides/003-slices.office-hero.md
+project: office-hero
+dateCreated: 20260524
+status: not_started
+---
+
+# Slice Design 013: Vehicle & VehicleCrew management
+
+This slice introduces the **Vehicle** aggregate and a date-scoped **VehicleCrew**
+assignment that pegs Technicians (existing `User` rows from slice 3) to a Vehicle for a single
+calendar date. A Vehicle can host **at most one VehicleCrew per date** (enforced by a unique
+constraint, not just service logic). VehicleCrew is the input the routing engine (Slice 13 of
+the master plan / design 014 in this batch) consumes when generating dispatch options.
+
+It implements **Slice 12** of the master slice plan.
+
+## Domain Model
+
+```text
+┌──────────┐     ┌───────────────────────┐     ┌────────────────────┐
+│ Vehicle  │ 1──N│  VehicleCrew (per     │ N──N│ Technician (User   │
+│          │     │  vehicle_id + date)   │     │ with role          │
+│          │     │                       │     │ Technician/Helper) │
+└──────────┘     └───────────────────────┘     └────────────────────┘
+                          │
+                          │ 1──N
+                          ▼
+                ┌─────────────────────────┐
+                │ VehicleCrewMember       │
+                │ (User + role_on_crew)   │
+                └─────────────────────────┘
+```
+
+* **Vehicle** is long-lived; identifies a physical truck/van.
+* **VehicleCrew** is for one day (`work_date`). Each entry lists the users on the truck for
+  that date and each user's role on that crew (Lead, Helper).
+* The unique constraint `(tenant_id, vehicle_id, work_date)` prevents a vehicle being assigned
+  to two crews on the same day.
+* A Technician (User) *can* appear on multiple Vehicles' crews on the same date — this is a
+  legal field operation if a tech rides as helper on a second truck after lunch — but is
+  flagged by `list_user_crew_conflicts()` for the Dispatcher UI. See Risk callouts.
+
+## Goals
+
+* Extend `src/office_hero/core/exceptions.py`:
+  * `class VehicleNotFoundError(Exception)`
+  * `class VehicleCrewNotFoundError(Exception)`
+  * `class CrewAssignmentConflictError(Exception)` — raised when a vehicle already has a crew
+    on `work_date`; carries existing `crew_id`.
+  * `class InvalidCrewMemberError(Exception)` — raised when a user is not a Technician /
+    Helper, is in another tenant, or is inactive.
+* Create `src/office_hero/core/crew_role.py` — `CrewRole` enum:
+  * `LEAD = "lead"` (one and only one per crew; the "driver" / journey-responsible tech)
+  * `HELPER = "helper"`
+  * `TRAINEE = "trainee"` (counted toward crew size but cannot lead a Job)
+  * Note: this is a **per-crew role** distinct from the user's RBAC `Role`. A user with RBAC
+    role `Technician` typically takes `LEAD`; `TechnicianHelper` users default to `HELPER`.
+* Create `src/office_hero/models/vehicle.py` — `Vehicle` ORM model:
+  * `id: Mapped[UUID]` (PK)
+  * `tenant_id: Mapped[UUID]` (FK, NOT NULL — RLS pivot)
+  * `license_plate: Mapped[str]` (20, NOT NULL — unique per tenant)
+  * `nickname: Mapped[str | None]` (120 — operator-friendly name, e.g. "Truck 7")
+  * `make: Mapped[str | None]` (60)
+  * `model: Mapped[str | None]` (60)
+  * `year: Mapped[int | None]` (CHECK 1980..2100)
+  * `vin: Mapped[str | None]` (17 — Vehicle Identification Number)
+  * `gps_device_id: Mapped[str | None]` (120 — optional hardware ID; used by Slice 15
+    location tracking to disambiguate when phone GPS is unavailable)
+  * `capacity_kg: Mapped[int | None]` (CHECK >= 0 — for plumbing/HVAC equipment limits;
+    informational for v1, may feed routing constraints later)
+  * `home_base_lat: Mapped[float | None]` (Numeric(9,6))
+  * `home_base_lng: Mapped[float | None]` (Numeric(9,6))
+  * `notes: Mapped[str | None]` (Text)
+  * `archived: Mapped[bool]` (default False — soft delete; archived vehicles are excluded from
+    routing candidate lists)
+  * `created_at`, `updated_at`
+  * `__table_args__`: unique `(tenant_id, license_plate)` where `archived=false`;
+    unique `(tenant_id, vin)` partial index where `vin IS NOT NULL`.
+  * `crews: Mapped[list["VehicleCrew"]] = relationship(back_populates="vehicle")`
+* Create `src/office_hero/models/vehicle_crew.py` — `VehicleCrew` and `VehicleCrewMember`:
+  * `class VehicleCrew(Base)`:
+    * `id: Mapped[UUID]` (PK)
+    * `tenant_id: Mapped[UUID]` (FK, NOT NULL — RLS)
+    * `vehicle_id: Mapped[UUID]` (FK `vehicles.id`, NOT NULL)
+    * `work_date: Mapped[date]` (NOT NULL)
+    * `shift_start: Mapped[time]` (NOT NULL, default `08:00`)
+    * `shift_end: Mapped[time]` (NOT NULL, default `17:00`)
+    * `notes: Mapped[str | None]` (Text — dispatcher's free-form annotation)
+    * `created_by_user_id: Mapped[UUID]` (FK users.id)
+    * `created_at`, `updated_at`
+    * `vehicle: Mapped["Vehicle"] = relationship(back_populates="crews")`
+    * `members: Mapped[list["VehicleCrewMember"]] = relationship(back_populates="crew",
+      cascade="all, delete-orphan")`
+    * `__table_args__`: unique `(tenant_id, vehicle_id, work_date)` — **the core invariant**.
+  * `class VehicleCrewMember(Base)`:
+    * `id: Mapped[UUID]` (PK)
+    * `tenant_id: Mapped[UUID]` (FK — denormalised for RLS even though redundant via crew)
+    * `crew_id: Mapped[UUID]` (FK `vehicle_crews.id` ON DELETE CASCADE)
+    * `user_id: Mapped[UUID]` (FK `users.id`, NOT NULL)
+    * `role_on_crew: Mapped[str]` (20 — `lead|helper|trainee`)
+    * `created_at`
+    * `__table_args__`: unique `(crew_id, user_id)` — a user can only appear once on a given
+      crew; CHECK constraint `role_on_crew IN ('lead','helper','trainee')`.
+* Update `src/office_hero/models/__init__.py` to import `Vehicle`, `VehicleCrew`,
+  `VehicleCrewMember`.
+* Create `src/office_hero/repositories/vehicle_repository.py`:
+  * `VehicleRepository` + `VehicleRepositoryProtocol`. Methods:
+    * `create(tenant_id, *, license_plate, nickname, make, model, year, vin, gps_device_id,
+      capacity_kg, home_base_lat, home_base_lng, notes) -> Vehicle`
+    * `get_by_id(vehicle_id, tenant_id) -> Vehicle | None`
+    * `list(tenant_id, *, archived=False, search=None, limit=50, offset=0)
+      -> tuple[list[Vehicle], int]`
+    * `update(vehicle_id, tenant_id, **patch) -> Vehicle`
+    * `archive(vehicle_id, tenant_id) -> Vehicle`
+    * `restore(vehicle_id, tenant_id) -> Vehicle`
+    * `list_active_for_date(tenant_id, work_date) -> list[Vehicle]` — vehicles that have a
+      VehicleCrew for the given date (used by routing in slice 14).
+* Create `src/office_hero/repositories/vehicle_crew_repository.py`:
+  * `VehicleCrewRepository` + protocol. Methods:
+    * `create(tenant_id, *, vehicle_id, work_date, shift_start, shift_end, notes,
+      created_by_user_id, members: list[CrewMemberInput]) -> VehicleCrew` — single transaction;
+      raises `CrewAssignmentConflictError` on duplicate `(vehicle_id, work_date)` via the unique
+      constraint (catch `IntegrityError`, look up existing, raise typed exception).
+    * `get_by_id(crew_id, tenant_id) -> VehicleCrew | None` — joinedload `members.user`.
+    * `get_for_vehicle_date(tenant_id, vehicle_id, work_date) -> VehicleCrew | None` —
+      the common query "what's this truck doing today?".
+    * `list_for_date(tenant_id, work_date) -> list[VehicleCrew]` — daily dispatch view.
+    * `list_for_user_date(tenant_id, user_id, work_date) -> list[VehicleCrew]` — "what am I on
+      today?", used by mobile auth + multi-truck conflict detection.
+    * `update(crew_id, tenant_id, *, shift_start, shift_end, notes) -> VehicleCrew` — fields
+      only; member changes go through dedicated methods.
+    * `replace_members(crew_id, tenant_id, members: list[CrewMemberInput]) -> VehicleCrew` —
+      atomic delete-then-insert (within transaction) so the unique `(crew_id, user_id)` invariant
+      is preserved.
+    * `add_member(crew_id, tenant_id, user_id, role_on_crew) -> VehicleCrewMember`
+    * `remove_member(crew_id, tenant_id, user_id) -> None`
+    * `delete(crew_id, tenant_id) -> None` — cascade deletes members.
+    * `find_user_crew_conflicts(tenant_id, work_date) -> list[tuple[UUID, list[UUID]]]` —
+      returns `[(user_id, [crew_id_a, crew_id_b]), ...]` for any user double-booked on the date.
+* Create `src/office_hero/services/vehicle_service.py`:
+  * `class VehicleService`:
+    * `__init__(repo, audit)`.
+    * `async def create(tenant_id, user_id, payload: VehicleCreate) -> Vehicle` — audit
+      `vehicle.created`.
+    * `async def update(tenant_id, user_id, vehicle_id, patch) -> Vehicle` — diff audit
+      `vehicle.updated`.
+    * `async def archive(tenant_id, user_id, vehicle_id) -> Vehicle` — refuses to archive a
+      vehicle with active (today's date or later) crews; raises a typed error mapped to 409.
+    * `async def restore(...)`, `async def get(...)`, `async def list(...)`.
+* Create `src/office_hero/services/vehicle_crew_service.py`:
+  * `class VehicleCrewService`:
+    * `__init__(crew_repo, vehicle_repo, user_repo, audit)`.
+    * `async def create(tenant_id, user_id, payload: VehicleCrewCreate) -> VehicleCrew`:
+      * Verifies vehicle exists and is not archived.
+      * Verifies `work_date` is not in the past more than 30 days (configurable;
+        prevents accidental backdated assignments — operators can override via a separate
+        admin-only endpoint, not in this slice).
+      * Verifies each `member.user_id`:
+        * Belongs to the same tenant.
+        * Is active (`user.active == True`).
+        * Has RBAC role in `{Technician, TechnicianHelper}`.
+        * Otherwise → `InvalidCrewMemberError`.
+      * Verifies exactly one member has `role_on_crew=LEAD`.
+      * `shift_end > shift_start`; both within 0..24h.
+      * Calls `crew_repo.create(...)` — relies on DB unique to enforce one crew per
+        `(vehicle, date)`; converts IntegrityError → `CrewAssignmentConflictError`.
+      * Audits `crew.created` with `{crew_id, vehicle_id, work_date, member_user_ids}`.
+    * `async def update_details(tenant_id, user_id, crew_id, patch) -> VehicleCrew` — shift,
+      notes only.
+    * `async def replace_members(tenant_id, user_id, crew_id, members) -> VehicleCrew` —
+      re-validates the LEAD constraint and per-user eligibility.
+    * `async def add_member(tenant_id, user_id, crew_id, user_id_to_add, role_on_crew)` — also
+      validates eligibility.
+    * `async def remove_member(tenant_id, user_id, crew_id, user_id_to_remove)` — refuses to
+      remove the LEAD without replacing it (server-side guard; UI also prevents).
+    * `async def delete(tenant_id, user_id, crew_id)` — audits `crew.deleted` with
+      `{crew_id, work_date, vehicle_id}`. Refuses to delete if a Route already references
+      this crew for the date (cross-slice safety; will become a real check once Slice 14 lands).
+    * `async def get(...)`, `async def list_for_date(...)`,
+      `async def get_for_vehicle_date(...)`,
+      `async def conflicts_for_date(tenant_id, work_date) -> list[CrewConflict]`.
+* Create `src/office_hero/api/schemas/vehicle.py`:
+  * `VehicleCreate`: `license_plate (1..20)`, `nickname?`, `make?`, `model?`, `year?
+    (1980..2100)`, `vin? (==17)`, `gps_device_id?`, `capacity_kg? (>=0)`,
+    `home_base_lat? (-90..90)`, `home_base_lng? (-180..180)`, `notes?`. `extra="forbid"`.
+  * `VehicleUpdate` — all fields optional, model_validator: at least one set.
+  * `VehicleRead`, `VehicleSummary`, `VehicleList`.
+* Create `src/office_hero/api/schemas/vehicle_crew.py`:
+  * `CrewMemberInput`: `{user_id: UUID, role_on_crew: CrewRole}`.
+  * `VehicleCrewCreate`: `{vehicle_id, work_date, shift_start (default "08:00"),
+    shift_end (default "17:00"), notes?, members: list[CrewMemberInput] (min 1)}`. Model
+    validator: exactly one member with `role_on_crew == "lead"`.
+  * `VehicleCrewUpdate`: `{shift_start?, shift_end?, notes?}`. (Member edits via dedicated endpoints.)
+  * `VehicleCrewMembersReplace`: `{members: list[CrewMemberInput]}` with lead invariant.
+  * `VehicleCrewRead`: full DTO with embedded `members: list[CrewMemberRead]` where
+    `CrewMemberRead = {user_id, email, full_name (when available), role_on_crew}`.
+  * `CrewConflictRead`: `{user_id, email, crew_ids: list[UUID], work_date}`.
+* Create `src/office_hero/api/routes/vehicles.py` — `prefix="/vehicles"`, `tags=["vehicles"]`:
+  * `POST /vehicles` — `@require_role([TenantAdmin, Operator, OperatorStaff])`.
+    (Dispatchers do not create vehicles; only admins.)
+  * `GET /vehicles` — `@require_permission("vehicles:read")` (granted to Dispatcher,
+    TenantAdmin, Operator).
+  * `GET /vehicles/{id}` — same.
+  * `PATCH /vehicles/{id}` — `@require_role([TenantAdmin, Operator, OperatorStaff])`.
+  * `POST /vehicles/{id}/archive` — same admin gate; 409 if active crews exist.
+  * `POST /vehicles/{id}/restore` — same admin gate.
+  * Rate-limited at `write` tier (60 req/min).
+* Create `src/office_hero/api/routes/vehicle_crews.py` — `prefix=""`, `tags=["crews"]`:
+  * `POST /vehicle-crews` — `@require_role([Dispatcher, TenantAdmin, Operator, OperatorStaff])`.
+    Body `VehicleCrewCreate`. **409** on `CrewAssignmentConflictError`; **422** on
+    `InvalidCrewMemberError`.
+  * `GET /vehicle-crews` — `@require_role([Dispatcher, TenantAdmin, Operator, Technician,
+    TechnicianHelper])`. Query: `work_date` (required), `vehicle_id?`, `user_id?`.
+    Technicians can list but are scoped to their own crews (service enforces).
+  * `GET /vehicle-crews/{id}` — same role set; Technicians can only read crews they're on.
+  * `PATCH /vehicle-crews/{id}` — `@require_role([Dispatcher, TenantAdmin, Operator])`.
+  * `PUT /vehicle-crews/{id}/members` — replace member roster atomically. Same gate.
+  * `POST /vehicle-crews/{id}/members` — add one. Same gate.
+  * `DELETE /vehicle-crews/{id}/members/{user_id}` — remove one. Same gate.
+  * `DELETE /vehicle-crews/{id}` — same gate.
+  * `GET /vehicle-crews/conflicts?date=YYYY-MM-DD` — `@require_role([Dispatcher,
+    TenantAdmin, Operator])`. Returns double-booked users for the day.
+* Update `src/office_hero/api/state.py` — `get_vehicle_service()`, `get_vehicle_crew_service()`.
+* Register routers in `src/office_hero/api/app.py`.
+* Update `src/office_hero/api/exception_handlers.py`:
+  * Map `VehicleNotFoundError`, `VehicleCrewNotFoundError` → 404.
+  * Map `CrewAssignmentConflictError` → **409** with `{detail, existing_crew_id}`.
+  * Map `InvalidCrewMemberError` → **422** with `{detail, user_id, reason}`.
+* Create migration `alembic/versions/0006_vehicles_and_crews.py`:
+  * Create `vehicles` table; FK `tenants(id)`; CHECK constraints on `year`, `capacity_kg`.
+  * Indexes: unique `(tenant_id, license_plate)` WHERE `archived=false`; partial unique
+    `(tenant_id, vin)` WHERE `vin IS NOT NULL`.
+  * `ALTER TABLE vehicles ENABLE ROW LEVEL SECURITY;` + tenant_isolation policy.
+  * Create `vehicle_crews` table; FK `tenants(id)`, FK `vehicles(id)`, FK
+    `users(id) as created_by`.
+  * Unique constraint `uq_vehicle_crew_vehicle_date` ON `(tenant_id, vehicle_id, work_date)`.
+  * Index `(tenant_id, work_date)` — daily view.
+  * `ALTER TABLE vehicle_crews ENABLE ROW LEVEL SECURITY;` + policy.
+  * Create `vehicle_crew_members` table; FK `tenants(id)`, FK `vehicle_crews(id) ON DELETE
+    CASCADE`, FK `users(id)`.
+  * Unique `(crew_id, user_id)`. CHECK `role_on_crew IN ('lead', 'helper', 'trainee')`.
+  * `ALTER TABLE vehicle_crew_members ENABLE ROW LEVEL SECURITY;` + policy.
+  * Downgrade drops everything in reverse.
+* Unit tests `tests/unit/test_vehicle_service.py`:
+  * `test_create_vehicle_returns_vehicle_and_audits`
+  * `test_create_vehicle_duplicate_plate_raises_conflict`
+  * `test_archive_vehicle_with_active_crew_today_refused`
+  * `test_archive_vehicle_with_only_past_crews_succeeds`
+  * `test_update_vehicle_partial_patch_emits_diff_audit`
+* Unit tests `tests/unit/test_vehicle_crew_service.py`:
+  * `test_create_crew_with_one_lead_succeeds`
+  * `test_create_crew_without_lead_raises`
+  * `test_create_crew_with_two_leads_raises`
+  * `test_create_crew_member_in_other_tenant_raises_invalid_member`
+  * `test_create_crew_member_with_inactive_user_raises_invalid_member`
+  * `test_create_crew_member_with_non_technician_role_raises_invalid_member`
+    (e.g. Dispatcher cannot be a crew lead)
+  * `test_create_crew_duplicate_vehicle_date_raises_assignment_conflict`
+  * `test_create_crew_archived_vehicle_raises_not_found`
+  * `test_create_crew_backdated_more_than_30_days_raises`
+  * `test_create_crew_shift_end_before_start_raises_422`
+  * `test_replace_members_keeps_lead_invariant`
+  * `test_remove_lead_member_without_replacement_refused`
+  * `test_conflicts_for_date_finds_double_booked_user`
+  * `test_delete_crew_when_routed_refused` (smoke; full check lands in slice 14)
+* API tests `tests/api/test_vehicles_api.py`:
+  * `test_post_vehicle_requires_admin_role` (Dispatcher 403)
+  * `test_post_vehicle_201_returns_id`
+  * `test_get_vehicles_dispatcher_can_read`
+  * `test_get_vehicles_technician_403`
+  * `test_archive_vehicle_with_today_crew_409`
+  * `test_vehicles_rate_limited_60_per_min`
+* API tests `tests/api/test_vehicle_crews_api.py`:
+  * `test_post_crew_dispatcher_succeeds`
+  * `test_post_crew_technician_403`
+  * `test_post_crew_duplicate_assignment_409`
+  * `test_post_crew_member_other_tenant_422_invalid_member`
+  * `test_post_crew_no_lead_422`
+  * `test_get_crews_for_date_dispatcher_sees_all`
+  * `test_get_crews_for_date_technician_sees_only_their_own`
+  * `test_get_crew_conflicts_returns_double_booked_user`
+  * `test_replace_members_keeps_unique_user_invariant`
+  * `test_remove_lead_without_replacement_refused`
+* Integration test `tests/integration/test_vehicle_crews_rls.py`:
+  * `test_rls_hides_other_tenant_vehicles`
+  * `test_unique_constraint_blocks_concurrent_double_assign` — two concurrent inserts of crews
+    for the same (vehicle, date); one wins, one gets IntegrityError → 409.
+  * `test_cascade_delete_members_on_crew_delete`
+
+## Structure
+
+```text
+src/office_hero/
+├── core/
+│   ├── exceptions.py            # +VehicleNotFoundError, +VehicleCrewNotFoundError,
+│   │                            #  +CrewAssignmentConflictError, +InvalidCrewMemberError
+│   └── crew_role.py             # CrewRole enum (lead/helper/trainee)
+├── models/
+│   ├── vehicle.py               # Vehicle ORM model
+│   └── vehicle_crew.py          # VehicleCrew + VehicleCrewMember
+├── repositories/
+│   ├── vehicle_repository.py
+│   └── vehicle_crew_repository.py
+├── services/
+│   ├── vehicle_service.py
+│   └── vehicle_crew_service.py
+└── api/
+    ├── schemas/
+    │   ├── vehicle.py
+    │   └── vehicle_crew.py
+    └── routes/
+        ├── vehicles.py
+        └── vehicle_crews.py
+
+alembic/
+└── versions/
+    └── 0006_vehicles_and_crews.py
+
+tests/
+├── unit/
+│   ├── test_vehicle_service.py
+│   └── test_vehicle_crew_service.py
+├── api/
+│   ├── test_vehicles_api.py
+│   └── test_vehicle_crews_api.py
+└── integration/
+    └── test_vehicle_crews_rls.py
+```
+
+## Failing Test Outline
+
+```python
+# tests/unit/test_vehicle_crew_service.py
+import pytest
+from datetime import date
+from office_hero.core.exceptions import (
+    CrewAssignmentConflictError, InvalidCrewMemberError,
+)
+
+
+@pytest.mark.asyncio
+async def test_create_crew_duplicate_vehicle_date_raises_assignment_conflict(
+    vehicle_crew_service, vehicle, tech_a, tech_b, dispatcher_user
+):
+    """A second crew on the same (vehicle, date) is rejected by the unique constraint."""
+    payload = make_crew_payload(vehicle_id=vehicle.id, work_date=date(2026, 6, 1),
+                                lead=tech_a)
+    await vehicle_crew_service.create(TENANT_A, dispatcher_user.id, payload)
+    with pytest.raises(CrewAssignmentConflictError) as exc:
+        dupe = make_crew_payload(vehicle_id=vehicle.id, work_date=date(2026, 6, 1),
+                                 lead=tech_b)
+        await vehicle_crew_service.create(TENANT_A, dispatcher_user.id, dupe)
+    assert exc.value.existing_crew_id is not None
+
+
+# tests/api/test_vehicle_crews_api.py
+def test_get_crews_for_date_technician_sees_only_their_own(
+    client, tech_a_token, todays_crew_with_tech_a, todays_crew_without_tech_a
+):
+    """Technician listing /vehicle-crews?work_date=today returns only crews they're on."""
+    resp = client.get(
+        f"/vehicle-crews?work_date={today_iso}",
+        headers={"Authorization": f"Bearer {tech_a_token}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    ids = {c["id"] for c in body["items"]}
+    assert todays_crew_with_tech_a.id in ids
+    assert todays_crew_without_tech_a.id not in ids
+```
+
+## Dependencies
+
+* **Slice 2 (Database foundation)** — RLS, Alembic.
+* **Slice 3 (Auth & RBAC)** — Role enum, JWT, decorators, `users` table for FK.
+* **Slice 4 (Observability)** — `AuditService`, exception handler.
+* **Slice 7 (Tenant management)** — tenants table for FK.
+* **Slice 8 (User management)** — user creation + activation flow (we re-use the existing
+  `users` table but tests need both Technician and Dispatcher users available).
+* Slice 11 (Customer & Location) is *not* a hard dependency — vehicles don't reference customers
+  — but file naming places it before this slice in the merge order.
+* Relevant ADRs: **053**, **058**, **059**, **060**, **062** (write tier), **063**.
+
+## Effort
+
+Estimate: **2/5**. Three tables, two services, two routers. Most rules are simple invariants
+(one lead per crew, unique vehicle+date assignment). The interesting work is `replace_members`
+needing to be transactional + atomic, and the cross-cutting `find_user_crew_conflicts` query.
+The `vehicle.archived` cross-check against active crews introduces a small temporal join but
+nothing exotic.
+
+## Risk Callouts
+
+* **Double-booked technicians.** A user appearing on two crews on the same date is *legal*
+  (split-shift help) but worth surfacing. The `conflicts` endpoint exists so the Dispatcher UI
+  can flag it. We do **not** enforce uniqueness on `(tenant_id, user_id, work_date)` — that
+  would break legitimate split-shift cases. **OPEN QUESTION:** stakeholders may want a configurable
+  per-tenant policy ("never allow double-booking"); deferred.
+* **Capacity_kg as a hint, not a constraint.** Routing (Slice 13) will ignore this in v1 — see
+  routing design risk callout. Document the field's intent in the model docstring.
+* **Vehicle archival ordering.** Archiving a vehicle with a future crew is refused with 409;
+  callers must delete the crew first. The error response must include the offending crew_id(s)
+  for the UI to act on. Tests assert this.
+* **Crew member RBAC role check.** We restrict crew membership to RBAC roles `Technician` and
+  `TechnicianHelper`. If a Dispatcher rides along, they cannot be on the crew — only
+  Technicians/Helpers can be assigned. **OPEN QUESTION:** should "Dispatcher in the truck for
+  the day" be representable? The current model says no; flagged in PR.
+* **GPS device ID nullable in v1.** Slice 15 (vehicle location tracking) will treat missing
+  `gps_device_id` as "phone-only tracking." Document this in the field comment.
+
+---
+
+Once approved, implementation proceeds: vehicle model + migration + service + tests; then the
+crew tables + service + tests; then the routers; conflicts query last. Slice 13 (routing) and
+14 (dispatch) consume the `list_active_for_date` and `get_for_vehicle_date` repository
+methods, so those must be locked down by the time this slice merges.

--- a/project-documents/user/slices/014-slice.routing-engine.md
+++ b/project-documents/user/slices/014-slice.routing-engine.md
@@ -1,0 +1,446 @@
+---
+docType: slice-design
+parent: ../project-guides/003-slices.office-hero.md
+project: office-hero
+dateCreated: 20260524
+status: not_started
+---
+
+# Slice Design 014: Routing engine integration
+
+This slice introduces the **routing subsystem**. It defines the `RoutingAdapter` protocol
+(per ADR 052) and an `ORSRoutingAdapter` HTTP client against the OpenRouteService API. It
+exposes `POST /jobs/{id}/routing-options` returning **three ranked options** — `nearest`,
+`earliest-completion`, `balanced-load` — over the candidate vehicles for the requested date.
+
+Routing is **read-only** at this stage: this slice does not persist Routes or commit dispatch
+(that is Slice 14 of the master plan, design 015 in this batch). It computes options on demand
+and returns them to the caller. Caching is in-memory per-request only.
+
+It implements **Slice 13** of the master slice plan.
+
+## Architecture Overview
+
+```text
+POST /jobs/{id}/routing-options
+        │
+        ▼
+RoutingService.compute_options(job_id, date, candidate_vehicle_ids)
+        │
+        ├── load job (with location lat/lng)
+        ├── load candidate vehicles + their crews for date
+        ├── load each vehicle's "current position" (Slice 15 will populate; here = home_base)
+        ├── load other jobs already scheduled to each candidate vehicle for the date
+        │
+        ▼
+RoutingAdapter.distance_matrix(origins, destinations)  ◄─── (ORS or Stub)
+RoutingAdapter.optimize_sequence(start, stops, end?)
+        │
+        ▼
+Rank three options (nearest / earliest / balanced)
+        │
+        ▼
+Return RoutingOptionsResponse
+```
+
+## Ranking Strategies
+
+For each candidate vehicle, the service computes:
+
+* `nearest_insertion_cost` — added distance (meters) to insert the new job at its best position
+  in that vehicle's existing sequence for the date. Lowest wins.
+* `earliest_completion_time` — projected `arrival_at_new_job + estimated_duration` given the
+  vehicle's current/last-known position and queued jobs. Earliest wins.
+* `balanced_load` — `existing_route_duration + new_job_duration` against the median across
+  candidate vehicles. The vehicle whose post-insertion load deviates least from the median
+  wins (favours load balancing across the fleet, not raw speed).
+
+The endpoint returns **one** option per strategy, totaling three options. Ties broken
+deterministically by `vehicle_id` UUID lex order so tests can assert exact outputs.
+
+## Goals
+
+* Add dependency to `pyproject.toml`: `httpx` (already present).
+* Extend `src/office_hero/core/config.py`:
+  * `ORS_BASE_URL: str = "https://api.openrouteservice.org"` (community endpoint).
+  * `ORS_API_KEY: str | None = None` (Fly.io secret; required when adapter is `ors`).
+  * `ORS_PROFILE: str = "driving-car"` (per ORS docs; future: `"driving-hgv"` for box trucks).
+  * `ORS_TIMEOUT_S: float = 8.0` (per ADR 052 SLO).
+  * `ORS_ALLOWLIST: list[str] = ["api.openrouteservice.org"]` — SSRF defence; the adapter
+    refuses to call any host outside this list.
+  * `ROUTING_ADAPTER: str = "ors"` (enum: `"ors" | "stub"`); auto-stub under `pytest` unless
+    overridden.
+  * `ROUTING_MAX_STOPS_PER_OPTIMIZE: int = 50` (ORS community ceiling is 50 for the optimization
+    endpoint; we enforce client-side to give a clean error instead of a 4xx).
+  * `ROUTING_CACHE_TTL_S: int = 30` — per-request distance matrix cache; in-memory only.
+* Extend `src/office_hero/core/exceptions.py`:
+  * `class RoutingError(Exception)` — base for routing-subsystem errors.
+  * `class RoutingTimeoutError(RoutingError)`.
+  * `class RoutingUnavailableError(RoutingError)` — non-2xx from ORS, or empty allowlist hit.
+  * `class NoCandidateVehiclesError(RoutingError)` — date has no crewed vehicles.
+  * `class JobNotRoutableError(RoutingError)` — job has no geocoded location (`lat/lng` null).
+  * `class TooManyStopsError(RoutingError)` — exceeds `ROUTING_MAX_STOPS_PER_OPTIMIZE`.
+* Create `src/office_hero/adapters/routing/__init__.py` (empty).
+* Create `src/office_hero/adapters/routing/types.py`:
+  * `@dataclass(frozen=True) class Coordinates`: `lat: float`, `lng: float`. Helper
+    `to_lonlat_tuple() -> tuple[float, float]` for ORS (which is lon-first).
+  * `@dataclass(frozen=True) class Stop`: `id: UUID` (job_id), `coords: Coordinates`,
+    `service_duration_s: int`, `priority: int = 50`.
+  * `@dataclass(frozen=True) class VehicleState`: `vehicle_id: UUID`, `current: Coordinates`,
+    `available_from: datetime`, `available_until: datetime`, `existing_sequence: list[Stop]`.
+  * `@dataclass(frozen=True) class DistanceCell`: `distance_m: int`, `duration_s: int`.
+  * `@dataclass(frozen=True) class RouteSegment`: `from_id: UUID | None` (None for the start),
+    `to_id: UUID`, `distance_m: int`, `duration_s: int`, `eta: datetime`.
+  * `@dataclass(frozen=True) class OptimizedRoute`: `vehicle_id: UUID`,
+    `sequence: list[UUID]` (job IDs in visit order), `segments: list[RouteSegment]`,
+    `total_distance_m: int`, `total_duration_s: int`, `arrival_at_target_s: int | None`.
+* Create `src/office_hero/adapters/routing/protocol.py`:
+  * `class RoutingAdapter(Protocol)`:
+    * `async def distance_matrix(self, origins: list[Coordinates],
+       destinations: list[Coordinates]) -> list[list[DistanceCell]]`
+    * `async def optimize_sequence(self, start: Coordinates, stops: list[Stop],
+       end: Coordinates | None = None) -> OptimizedRoute` — start is fixed (vehicle's current
+      position); `end` optional return-to-base; stops are reordered for minimum total time.
+    * `async def health_check(self) -> bool` — used by `GET /health` (slice 4).
+* Create `src/office_hero/adapters/routing/ors.py` — `ORSRoutingAdapter`:
+  * `__init__(base_url, api_key, profile, timeout, allowlist, http_client: httpx.AsyncClient
+    | None = None)`.
+    * Validates `base_url` host against `allowlist` on construction (raises
+      `RoutingUnavailableError`).
+    * If `api_key is None and base_url.host != "localhost"`, raises a config-time error
+      (catch in app startup).
+  * `async def distance_matrix(...)`:
+    * Calls `POST {base_url}/v2/matrix/{profile}` with body
+      `{"locations": [[lng,lat], ...], "sources": [...], "destinations": [...],
+       "metrics": ["distance", "duration"]}`.
+    * Header: `Authorization: <api_key>` (per ORS spec — no `Bearer` prefix).
+    * Translates the response into `list[list[DistanceCell]]`. Both `distances` and
+      `durations` arrays returned by ORS are aligned with `sources × destinations`.
+    * Catches `httpx.TimeoutException` → `RoutingTimeoutError`; non-2xx →
+      `RoutingUnavailableError(detail=status_code, body_excerpt)`.
+  * `async def optimize_sequence(...)`:
+    * Two-tier strategy:
+      1. If `len(stops) <= 10`, call `/v2/directions/{profile}/json` with the stop list in input
+         order — used to surface segment-level ETAs for already-optimized sequences (cheap).
+      2. Otherwise call `/optimization` (ORS Optimization API, VROOM-based) with one vehicle
+         and stops as jobs; profile mapped to ORS `vehicles[0].profile`.
+    * Validates `len(stops) <= ROUTING_MAX_STOPS_PER_OPTIMIZE`; else `TooManyStopsError`.
+    * Builds `OptimizedRoute`. ETAs are derived by summing segment durations starting from
+      `available_from` of the vehicle (the *service* passes that as a base time; the adapter
+      doesn't know wall-clock semantics).
+  * `async def health_check(self) -> bool`:
+    * Calls `GET {base_url}/v2/health` (or the documented health endpoint at the time of
+      implementation; document the exact path in code).
+    * Returns True on 200 within timeout, False otherwise (never raises).
+  * Logging: every call emits structured logs `routing.ors.request_started` and
+    `routing.ors.request_completed` with `duration_ms`, `status_code`, and a **redacted**
+    `endpoint`. The API key is never logged.
+* Create `src/office_hero/adapters/routing/stub.py` — `StubRoutingAdapter` for tests:
+  * Deterministic euclidean distance × 1.3 (rough road-detour factor); 40 km/h average speed
+    → duration_s. Optimization runs a nearest-neighbour pass from `start`, then a single
+    2-opt sweep. Cheap, predictable, no network.
+  * `health_check()` returns True.
+* Create `src/office_hero/adapters/routing/factory.py` — `build_routing_adapter(settings) ->
+  RoutingAdapter`. Honours `pytest` auto-stub.
+* Create `src/office_hero/services/routing_service.py` — `RoutingService`:
+  * `__init__(adapter: RoutingAdapter, job_repo, location_repo, vehicle_repo,
+    vehicle_crew_repo, audit: AuditService)`.
+  * `async def compute_options(tenant_id, user_id, *, job_id: UUID, work_date: date,
+    vehicle_ids: list[UUID] | None = None) -> RoutingOptionsResponse`:
+    1. Load the target job + its location. If `lat/lng` is missing → `JobNotRoutableError`.
+    2. Resolve candidate vehicles:
+       * If `vehicle_ids` provided, validate each belongs to the tenant and has a crew on
+         `work_date` (`vehicle_crew_repo.get_for_vehicle_date`). Reject the lot if any single
+         vehicle is invalid → `NoCandidateVehiclesError` with reasons.
+       * Else: `vehicle_repo.list_active_for_date(tenant_id, work_date)`. Empty → raise.
+    3. For each candidate vehicle, build a `VehicleState`:
+       * `current = vehicle.home_base_lat/lng` (Slice 15 will replace with last-known position).
+       * `available_from = combine(work_date, crew.shift_start, tenant_timezone)`.
+       * `available_until = combine(work_date, crew.shift_end, ...)`.
+       * `existing_sequence`: `job_repo.list_due_for_routing(tenant_id, work_date)` filtered
+         to jobs already pegged to this vehicle (joins added in slice 15). For this slice,
+         `existing_sequence` is the empty list — populated once Slice 15 lands routes.
+         **OPEN QUESTION:** confirm with stakeholders that v1 routing assumes no prior
+         commitments on the truck on the date; flagged in PR.
+    4. Build the **distance matrix** for `[vehicle_current, ...existing_stops, new_job]`
+       once per vehicle. Cache by `(vehicle_id, work_date)` for the request.
+    5. Compute three strategies via internal helpers:
+       * `_strategy_nearest(states)` → vehicle with min insertion cost.
+       * `_strategy_earliest(states)` → vehicle whose insertion has earliest arrival_at_target.
+       * `_strategy_balanced(states)` → vehicle minimising `abs(load_after - median_load)`.
+    6. For each chosen vehicle, call `adapter.optimize_sequence(start=vehicle.current,
+       stops=existing_stops + [new_stop], end=vehicle.current_or_home)` to get the canonical
+       segment-level route.
+    7. Assemble `RoutingOption` per strategy; emit audit `routing.options_computed` with
+       `{job_id, work_date, candidate_count, chosen_vehicle_ids: {nearest, earliest, balanced}}`.
+       No PII; just IDs.
+    8. Return `RoutingOptionsResponse`.
+  * If any **two** strategies pick the **same** vehicle with the same sequence, both options
+    are still returned (deduplication is the UI's job in Slice 14); but the service includes a
+    `note` on each duplicate option for the caller to deduplicate cleanly.
+* Create `src/office_hero/api/schemas/routing.py`:
+  * `RoutingOptionsRequest`: `{vehicle_ids?: list[UUID], date: date}`.
+    * `vehicle_ids` optional; when omitted, all vehicles with crews on `date` are candidates.
+    * `model_config = ConfigDict(extra="forbid")`.
+  * `RouteSegmentRead`: `{from_id?: UUID, to_id: UUID, distance_m: int, duration_s: int,
+    eta: datetime}`.
+  * `RoutingOptionRead`: `{kind: Literal["nearest","earliest","balanced"], vehicle_id: UUID,
+    route_sequence: list[UUID], segments: list[RouteSegmentRead], total_distance_m: int,
+    estimated_duration_s: int, notes: list[str]}`.
+  * `RoutingOptionsResponse`: `{options: list[RoutingOptionRead]}` (always length 3 unless
+    `NoCandidateVehiclesError` raised earlier, which maps to 422).
+* Create `src/office_hero/api/routes/routing.py`:
+  * `POST /jobs/{job_id}/routing-options` — `@require_permission("jobs:dispatch")`. Body
+    `RoutingOptionsRequest`. Tagged `["routing"]`.
+  * Rate-limited at a **dedicated** tier: `routing` = 30 req/min/user (lower than `write` 60
+    because each call may fan out to ORS). The slowapi limiter manager (slice 4) already
+    supports per-name limits — define `routing` in the bootstrap config record.
+* Update `src/office_hero/api/state.py`:
+  * `get_routing_adapter() -> RoutingAdapter`
+  * `get_routing_service() -> RoutingService`
+* Update `src/office_hero/api/routes/health.py` (from slice 4):
+  * Health check calls `routing_adapter.health_check()`; degraded state if False but DB ok.
+  * Result reported as `"ors": "ok|degraded|error"`.
+* Update `src/office_hero/api/exception_handlers.py`:
+  * `RoutingTimeoutError` → **504 Gateway Timeout** (`{detail: "Routing engine timed out"}`).
+  * `RoutingUnavailableError` → **502 Bad Gateway** (`{detail, request_id}`).
+  * `NoCandidateVehiclesError` → **422** (`{detail, vehicle_id?, reason?}`).
+  * `JobNotRoutableError` → **422** (`{detail: "Job location not geocoded"}`).
+  * `TooManyStopsError` → **422** (`{detail, limit}`).
+* **No migration in this slice.** No new tables. (Persistence comes in slice 015 / master 14.)
+* Unit tests `tests/unit/test_routing_service.py`:
+  * `test_compute_options_returns_three_kinds`
+  * `test_compute_options_orders_kinds_consistently` (always nearest, earliest, balanced)
+  * `test_compute_options_with_explicit_vehicle_ids_filters_candidates`
+  * `test_compute_options_job_without_location_lat_raises_not_routable`
+  * `test_compute_options_no_crewed_vehicles_raises_no_candidates`
+  * `test_compute_options_explicit_vehicle_without_crew_raises_no_candidates`
+  * `test_compute_options_explicit_vehicle_in_other_tenant_raises_not_found_then_no_candidates`
+  * `test_compute_options_caches_distance_matrix_per_request`
+  * `test_compute_options_emits_audit_event_with_ids_only_no_pii`
+  * `test_nearest_strategy_picks_min_insertion`
+  * `test_earliest_strategy_picks_min_arrival_time`
+  * `test_balanced_strategy_picks_closest_to_median_load`
+  * `test_tie_break_by_vehicle_id_uuid_lex_order`
+* Unit tests `tests/unit/test_ors_routing_adapter.py` (httpx mocked):
+  * `test_ors_distance_matrix_translates_response`
+  * `test_ors_distance_matrix_4xx_raises_unavailable`
+  * `test_ors_distance_matrix_5xx_raises_unavailable`
+  * `test_ors_distance_matrix_timeout_raises_routing_timeout`
+  * `test_ors_distance_matrix_sends_api_key_header`
+  * `test_ors_distance_matrix_uses_lonlat_order`
+  * `test_ors_optimize_small_stops_uses_directions_endpoint`
+  * `test_ors_optimize_large_stops_uses_optimization_endpoint`
+  * `test_ors_optimize_exceeds_max_stops_raises_too_many_stops`
+  * `test_ors_constructor_rejects_host_outside_allowlist` (SSRF)
+  * `test_ors_constructor_rejects_private_ip_in_url` (SSRF — `192.168.*`, `10.*`, `127.0.0.1`,
+    `169.254.169.254` metadata)
+  * `test_ors_does_not_log_api_key`
+  * `test_ors_health_check_returns_false_on_timeout`
+* Unit tests `tests/unit/test_stub_routing_adapter.py`:
+  * `test_stub_distance_matrix_deterministic_for_fixed_inputs`
+  * `test_stub_optimize_sequence_returns_consistent_ordering`
+  * `test_stub_health_check_always_true`
+* API tests `tests/api/test_routing_api.py`:
+  * `test_post_routing_options_requires_jwt_401`
+  * `test_post_routing_options_without_jobs_dispatch_perm_403` (Technician)
+  * `test_post_routing_options_unknown_job_404`
+  * `test_post_routing_options_cross_tenant_job_404`
+  * `test_post_routing_options_job_without_geocode_422`
+  * `test_post_routing_options_no_crewed_vehicles_422`
+  * `test_post_routing_options_returns_three_options` (stub adapter)
+  * `test_post_routing_options_explicit_vehicle_ids_respected`
+  * `test_post_routing_options_response_shape_matches_schema`
+  * `test_post_routing_options_rate_limited_30_per_min`
+  * `test_post_routing_options_ors_timeout_returns_504` (httpx mock makes adapter raise)
+  * `test_post_routing_options_ors_5xx_returns_502`
+  * `test_post_routing_options_ors_does_not_leak_api_key_to_client`
+    (force an error path, assert response body contains no env or header data)
+* Integration test (optional, gated on `RUN_ORS_INTEGRATION=1`):
+  * `tests/integration/test_routing_ors_live.py` — runs against a **Dockerized** ORS instance
+    (`openrouteservice/openrouteservice:latest` with a small OSM extract — `docs/ors-dev.md` to
+    be written). Asserts a real distance matrix call succeeds and the response shape matches.
+    Skipped in default CI; on-demand only.
+* Document the local ORS Docker setup in `docs/ors-dev.md` (new):
+  * Pull image, mount a tiny OSM `.pbf` extract (US-Northeast small region from Geofabrik),
+    expose on `localhost:8080`, set `ORS_BASE_URL=http://localhost:8080/ors`.
+  * Note: integration test only — production is community ORS until Slice 13 self-host
+    promotion (see ADR 052).
+
+## Structure
+
+```text
+src/office_hero/
+├── adapters/
+│   └── routing/
+│       ├── __init__.py
+│       ├── protocol.py          # RoutingAdapter Protocol + types
+│       ├── types.py             # Coordinates, Stop, VehicleState, OptimizedRoute, ...
+│       ├── ors.py               # ORSRoutingAdapter
+│       ├── stub.py              # StubRoutingAdapter
+│       └── factory.py
+├── services/
+│   └── routing_service.py
+├── api/
+│   ├── schemas/
+│   │   └── routing.py
+│   └── routes/
+│       └── routing.py
+└── core/
+    ├── config.py                # +ORS_*, +ROUTING_*
+    └── exceptions.py            # +RoutingError, +RoutingTimeoutError,
+                                 #  +RoutingUnavailableError, +NoCandidateVehiclesError,
+                                 #  +JobNotRoutableError, +TooManyStopsError
+
+tests/
+├── unit/
+│   ├── test_routing_service.py
+│   ├── test_ors_routing_adapter.py
+│   └── test_stub_routing_adapter.py
+├── api/
+│   └── test_routing_api.py
+└── integration/
+    └── test_routing_ors_live.py  # gated; runs against local Dockerized ORS
+
+docs/
+└── ors-dev.md                    # Local Dockerized ORS setup notes
+```
+
+## Failing Test Outline
+
+```python
+# tests/unit/test_routing_service.py
+import pytest
+from datetime import date
+from office_hero.core.exceptions import (
+    JobNotRoutableError, NoCandidateVehiclesError,
+)
+
+
+@pytest.mark.asyncio
+async def test_compute_options_job_without_location_lat_raises_not_routable(
+    routing_service, ungeocoded_job
+):
+    """A job with null lat/lng cannot be routed → 422 mapped error."""
+    with pytest.raises(JobNotRoutableError):
+        await routing_service.compute_options(
+            tenant_id=TENANT_A, user_id=DISPATCHER, job_id=ungeocoded_job.id,
+            work_date=date(2026, 6, 1), vehicle_ids=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_compute_options_returns_three_kinds(
+    routing_service, routable_job, two_crewed_vehicles
+):
+    """A normal call yields exactly three options, one per strategy."""
+    resp = await routing_service.compute_options(
+        tenant_id=TENANT_A, user_id=DISPATCHER, job_id=routable_job.id,
+        work_date=date(2026, 6, 1), vehicle_ids=None,
+    )
+    kinds = [o.kind for o in resp.options]
+    assert kinds == ["nearest", "earliest", "balanced"]
+
+
+# tests/unit/test_ors_routing_adapter.py
+@pytest.mark.asyncio
+async def test_ors_constructor_rejects_host_outside_allowlist():
+    """Passing a base_url outside ORS_ALLOWLIST must fail at construction (SSRF)."""
+    with pytest.raises(RoutingUnavailableError):
+        ORSRoutingAdapter(
+            base_url="http://attacker.example.com",
+            api_key="k", profile="driving-car", timeout=5.0,
+            allowlist=["api.openrouteservice.org"],
+        )
+
+
+# tests/api/test_routing_api.py
+def test_post_routing_options_ors_timeout_returns_504(
+    client, dispatcher_token, routable_job, ors_timeout_mock
+):
+    """An ORS timeout propagates as 504 with no stack trace."""
+    resp = client.post(
+        f"/jobs/{routable_job.id}/routing-options",
+        json={"date": "2026-06-01"},
+        headers={"Authorization": f"Bearer {dispatcher_token}"},
+    )
+    assert resp.status_code == 504
+    assert "traceback" not in resp.text.lower()
+    assert "request_id" in resp.json()
+```
+
+## Dependencies
+
+* **Slice 2 (Database foundation)** — async engine; no new tables here.
+* **Slice 3 (Auth & RBAC)** — JWT, `@require_permission("jobs:dispatch")`.
+* **Slice 4 (Observability)** — health endpoint, exception handler integration, rate limit
+  manager (needs a new `routing` limit row in `rate_limits` seed).
+* **Slice 11 (Customer & Location)** — provides `Location.lat/lng` and the
+  `LocationRepository.get_by_id` used to fetch the job's location.
+* **Slice 12 (Job management)** — provides `Job`, `JobRepository.get_by_id`, and
+  `list_due_for_routing` (used for vehicle existing-sequence loading; currently returns []).
+* **Slice 13 (Vehicle & VehicleCrew)** — provides `Vehicle`, `VehicleCrew`,
+  `vehicle_repo.list_active_for_date`, `vehicle_crew_repo.get_for_vehicle_date`.
+* Relevant ADRs: **052** (ORS choice), **053** (RLS), **060** (RBAC),
+  **062** (rate limiting — new `routing` tier), **063** (logging; no PII in audit), and the
+  HLD §Security A10 (SSRF allowlist).
+* This slice **does not** depend on Slice 15 (vehicle location tracking) — vehicle "current"
+  position falls back to `home_base_lat/lng`. Slice 15 will replace that source without changing
+  this slice's API surface.
+
+## Effort
+
+Estimate: **3/5**. The adapter is moderate: two ORS endpoints (matrix + optimization), an
+allowlist check, error-class translation, and a deterministic stub adapter. The ranking logic
+is the substantive design work — three strategies that must be reproducible for tests. ORS
+quirks (lon/lat ordering, header without `Bearer`, optimization endpoint vs directions
+endpoint, response shape) absorb a chunk of implementation time. The integration test against
+Dockerized ORS is optional but recommended once before merge.
+
+## Risk Callouts
+
+* **SSRF.** The biggest risk. The ORS adapter must refuse any host outside
+  `ORS_ALLOWLIST`. We also block private IP ranges (`10.0.0.0/8`, `172.16.0.0/12`,
+  `192.168.0.0/16`, `127.0.0.0/8`, `169.254.0.0/16`, `0.0.0.0/8`, `::1`, link-local) at the
+  HTTP-client layer using a custom `httpx` transport that resolves and validates before
+  connecting. Tested. The `Coordinates` payload itself cannot trigger SSRF because the URL is
+  static.
+* **API key leakage.** The ORS API key sits in Fly.io secrets; never logged, never in error
+  responses. Test `test_ors_does_not_log_api_key` asserts this on every error path.
+* **Rate limiting against ORS community.** ORS community is 500 req/day per ADR 052. We add
+  the in-process `routing` slowapi limit (30 req/min/user) and document that under load, this
+  slice's effective ceiling is the **upstream** quota — a 502/504 from us is the visible
+  symptom. **Mitigation:** the Operator dashboard can adjust `rate_limits.routing.limit`
+  downward at runtime per ADR 062.
+* **Distance matrix complexity.** Naive distance matrix scales O(N²) in stops; ORS matrix call
+  is capped at 50 sources × 50 destinations. We pre-validate `stops_count <= 50` and surface
+  `TooManyStopsError → 422` before calling ORS. **Future work:** for fleets > 50 stops/day
+  we partition the matrix into per-vehicle chunks (each vehicle's existing sequence + the new
+  job ≤ 50 in practice).
+* **Optimization correctness vs determinism.** ORS VROOM optimization is deterministic given
+  the same input but the input includes timestamps that we generate. Tests use the stub
+  adapter for service-level determinism; the ORS-live integration test only asserts shape and
+  monotonicity (e.g. `total_duration_s > 0`).
+* **Empty existing sequences (v1).** Until Slice 15 commits Routes, every vehicle's
+  `existing_sequence` is empty. Strategies will collapse: `nearest` reduces to "vehicle closest
+  to the new job"; `earliest` becomes "vehicle whose home base + travel arrives soonest";
+  `balanced` becomes "vehicle whose lone-job load is closest to the median (i.e., basically a
+  tie among all vehicles)". **OPEN QUESTION:** is a single-job v1 worth shipping? Stakeholder
+  alignment needed; flagged in PR. Mitigation: ship now to unblock Slice 14 UI; revisit
+  ranking quality once Slice 15 is in.
+* **Vehicle current position fallback to home base.** Honest about the v1 limitation in API
+  schema docstrings and response notes (`option.notes: ["Vehicle position is home_base; live
+  tracking not yet enabled."]`).
+* **ORS health endpoint path.** The exact `/v2/health` path has changed across ORS versions;
+  implementer must verify against the ORS version at integration time and document in
+  `adapters/routing/ors.py`. Marked as a code-review checklist item.
+* **Audit payload privacy.** The audit event records job_id + vehicle_ids only — no
+  coordinates, no customer info. ADR 063 alignment.
+
+---
+
+Once approved, implementation proceeds adapter-first: types + protocol + stub + tests (full
+green), then the ORS adapter with httpx mocks (no live calls in CI), then `RoutingService`
+with ranking strategies (TDD with the stub), then the API route + error handlers, then the
+`routing` rate-limit seed. The optional Dockerized ORS test runs manually before merge to
+sanity-check the live wiring.

--- a/project-documents/user/slices/015-slice.dispatch-route.md
+++ b/project-documents/user/slices/015-slice.dispatch-route.md
@@ -1,0 +1,544 @@
+---
+docType: slice-design
+parent: ../project-guides/003-slices.office-hero.md
+project: office-hero
+dateCreated: 20260524
+status: not_started
+---
+
+# Slice Design 015: Dispatch & Route management
+
+This slice commits the result of a routing-options call (Slice 014) into a persistent **Route**
+with ordered **RouteStops**. It introduces a strict Route status lifecycle, atomic
+dispatch-commit (single transaction across Route + RouteStops + per-Job status transitions),
+a manual fourth-option escape hatch, and a daily-view read endpoint.
+
+It implements **Slice 14** of the master slice plan.
+
+## Domain Model
+
+```text
+┌──────────────────────────────┐
+│ Route                        │
+│  vehicle_id, work_date       │ 1
+│  status (draft/committed/    │ ──┐
+│   in_progress/complete/      │   │  N
+│   cancelled)                 │   └────────┐
+│  total_distance_m            │            ▼
+│  total_duration_s            │   ┌──────────────────┐
+└──────────────────────────────┘   │ RouteStop        │
+                                   │  job_id          │
+                                   │  sequence_index  │
+                                   │  eta             │
+                                   │  status (pending │
+                                   │   /arrived/      │
+                                   │   complete/      │
+                                   │   skipped)       │
+                                   └──────────────────┘
+```
+
+* A **Route** is uniquely keyed by `(tenant_id, vehicle_id, work_date)` — at most one Route per
+  vehicle per day. A second dispatch to the same vehicle on the same day **updates** the
+  existing Route (appending the Job as a new RouteStop) rather than creating a new Route. This
+  is the spec's "Commit dispatch creates/updates Route + RouteStops" requirement.
+* A **RouteStop** references one Job and pegs its `sequence_index` (0..N) and projected `eta`.
+  RouteStops are ordered; the `(route_id, sequence_index)` pair is unique.
+
+## Route Status Lifecycle
+
+```text
+draft ──► committed ──► in_progress ──► complete
+   │           │                │
+   └── cancel ─┴────cancel──────┘
+                      │
+                      ▼
+                  cancelled
+```
+
+* `draft` exists only momentarily — the dispatch endpoint commits within the same DB
+  transaction. We keep `draft` as a status so a future "preview dispatch" feature has a place
+  to land without a migration. **OPEN QUESTION:** stakeholders may prefer omitting `draft`
+  entirely; flagged in PR. The default behaviour: dispatch jumps straight to `committed`.
+* `committed → in_progress` triggered when the first Job on the Route is started (event from
+  Slice 012 `JobService.start`).
+* `in_progress → complete` triggered when all RouteStops are `complete` or `skipped` (terminal
+  per-stop statuses), via a route-status-recompute callback.
+* Cancellation is dispatcher-initiated; cascades to set each non-terminal RouteStop status to
+  `skipped` and emits `route.cancelled` audit; **does not** automatically cancel the underlying
+  Jobs (those return to `pending` for re-dispatch).
+
+## Goals
+
+* Extend `src/office_hero/core/exceptions.py`:
+  * `class RouteNotFoundError(Exception)`.
+  * `class InvalidRouteTransitionError(Exception)` — carries `from_status`, `to_status`.
+  * `class RouteCommitConflictError(Exception)` — raised when the committed sequence conflicts
+    with the latest state (e.g. a referenced Job no longer exists, or the chosen vehicle no
+    longer has a crew on the date). Carries machine-readable `reason`.
+  * `class ManualSequenceInvalidError(Exception)` — manual fourth-option payload had duplicate
+    or non-tenant job ids, etc.
+* Create `src/office_hero/core/route_status.py`:
+  * `RouteStatus` enum: `DRAFT, COMMITTED, IN_PROGRESS, COMPLETE, CANCELLED`.
+  * `RouteStopStatus` enum: `PENDING, ARRIVED, COMPLETE, SKIPPED`.
+  * Transition matrix for `RouteStatus` mirroring the lifecycle above.
+  * Per-stop transitions: `pending → arrived → complete`, plus `pending|arrived → skipped`.
+  * `can_route_transition(from, to)`, `can_stop_transition(from, to)`, `is_terminal_route(...)`,
+    `is_terminal_stop(...)`.
+* Create `src/office_hero/models/route.py`:
+  * `class Route(Base)`:
+    * `id: Mapped[UUID]` (PK)
+    * `tenant_id: Mapped[UUID]` (FK, NOT NULL — RLS)
+    * `vehicle_id: Mapped[UUID]` (FK `vehicles.id`, NOT NULL)
+    * `vehicle_crew_id: Mapped[UUID]` (FK `vehicle_crews.id`, NOT NULL — pegs the crew
+      assignment used at commit time; if the crew is later edited, this link survives)
+    * `work_date: Mapped[date]` (NOT NULL)
+    * `status: Mapped[str]` (20, NOT NULL, default `"draft"`)
+    * `committed_at: Mapped[datetime | None]`
+    * `started_at: Mapped[datetime | None]`
+    * `completed_at: Mapped[datetime | None]`
+    * `cancelled_at: Mapped[datetime | None]`
+    * `cancel_reason: Mapped[str | None]` (Text)
+    * `total_distance_m: Mapped[int]` (NOT NULL, default 0)
+    * `total_duration_s: Mapped[int]` (NOT NULL, default 0)
+    * `option_kind_applied: Mapped[str | None]` (20 — `"nearest"|"earliest"|"balanced"|"manual"`;
+      provenance for audits)
+    * `committed_by_user_id: Mapped[UUID | None]` (FK `users.id`)
+    * `notes: Mapped[str | None]` (Text)
+    * `created_at`, `updated_at`
+    * `vehicle: Mapped["Vehicle"] = relationship()`
+    * `crew: Mapped["VehicleCrew"] = relationship()`
+    * `stops: Mapped[list["RouteStop"]] = relationship(back_populates="route",
+      cascade="all, delete-orphan", order_by="RouteStop.sequence_index")`
+    * `__table_args__`: unique `(tenant_id, vehicle_id, work_date)`;
+      index `(tenant_id, work_date)`; index `(tenant_id, status)`.
+  * `class RouteStop(Base)`:
+    * `id: Mapped[UUID]` (PK)
+    * `tenant_id: Mapped[UUID]` (FK — denormalised for RLS)
+    * `route_id: Mapped[UUID]` (FK `routes.id` ON DELETE CASCADE)
+    * `job_id: Mapped[UUID]` (FK `jobs.id`, NOT NULL)
+    * `sequence_index: Mapped[int]` (NOT NULL — 0-based; recomputed atomically on insert)
+    * `status: Mapped[str]` (20, NOT NULL, default `"pending"`)
+    * `planned_eta: Mapped[datetime | None]` (eta at commit time)
+    * `actual_arrived_at: Mapped[datetime | None]`
+    * `actual_completed_at: Mapped[datetime | None]`
+    * `planned_distance_from_prev_m: Mapped[int]` (NOT NULL, default 0)
+    * `planned_duration_from_prev_s: Mapped[int]` (NOT NULL, default 0)
+    * `created_at`, `updated_at`
+    * `route: Mapped["Route"] = relationship(back_populates="stops")`
+    * `job: Mapped["Job"] = relationship()`
+    * `__table_args__`: unique `(route_id, sequence_index)`; unique `(route_id, job_id)`
+      (a Job can appear at most once on a Route — re-dispatching to the same vehicle should
+      update the existing stop, not duplicate).
+* Update `src/office_hero/models/__init__.py` to import `Route`, `RouteStop`.
+* Create `src/office_hero/repositories/route_repository.py`:
+  * `RouteRepository` + protocol. Methods:
+    * `get_by_id(route_id, tenant_id) -> Route | None` (joinedload stops + job + customer).
+    * `get_for_vehicle_date(tenant_id, vehicle_id, work_date) -> Route | None`.
+    * `list_for_date(tenant_id, work_date, *, vehicle_id: UUID | None = None,
+      status: list[str] | None = None) -> list[Route]` — daily view; ordered by
+      `(vehicle.nickname, vehicle.license_plate)` for deterministic UI.
+    * `list_for_user_date(tenant_id, user_id, work_date) -> list[Route]` — routes whose crew
+      includes the user (technician mobile view).
+    * `create(tenant_id, *, vehicle_id, vehicle_crew_id, work_date,
+      option_kind_applied, committed_by_user_id, notes, total_distance_m, total_duration_s)
+      -> Route`
+    * `update_status(route_id, tenant_id, new_status, *, committed_at=None, started_at=None,
+      completed_at=None, cancelled_at=None, cancel_reason=None) -> Route`.
+    * `update_totals(route_id, tenant_id, *, total_distance_m, total_duration_s) -> Route`.
+    * `delete(route_id, tenant_id)` — admin-only; cascade deletes stops.
+* Create `src/office_hero/repositories/route_stop_repository.py`:
+  * `RouteStopRepository` + protocol. Methods:
+    * `bulk_insert(tenant_id, route_id, stops: list[StopRow]) -> list[RouteStop]` — within an
+      ambient transaction; respects `(route_id, sequence_index)` invariant.
+    * `delete_for_route(tenant_id, route_id) -> int` (returns count).
+    * `replace_all(tenant_id, route_id, stops: list[StopRow]) -> list[RouteStop]` — atomic
+      delete-then-insert (within a single transaction); for re-dispatch of the same vehicle
+      with a re-sequenced set of stops.
+    * `update_status(stop_id, tenant_id, new_status, *, arrived_at=None, completed_at=None)
+      -> RouteStop` — guarded by `can_stop_transition`.
+    * `get_for_route(tenant_id, route_id) -> list[RouteStop]`.
+* Create `src/office_hero/services/dispatch_service.py` — `DispatchService`:
+  * `__init__(route_repo, stop_repo, job_repo, vehicle_repo, vehicle_crew_repo,
+    routing_service: RoutingService, audit: AuditService)`.
+  * `async def commit_dispatch(tenant_id, user_id, *, job_id: UUID,
+    payload: DispatchCommitRequest) -> Route`:
+    * **Branch A (option mode):** `payload.option_kind` is set (one of
+      `"nearest"|"earliest"|"balanced"`):
+      1. Re-fetch the latest routing options via `routing_service.compute_options(...)` to
+         ensure we commit a fresh sequence (the cached options on the client may be stale —
+         tenant data could have changed between options call and commit).
+      2. Select the option matching `option_kind`.
+    * **Branch B (manual mode):** `payload.manual_vehicle_id` and
+      `payload.manual_sequence: list[UUID]` are set:
+      1. Validate the vehicle has a crew on `payload.date` (else `RouteCommitConflictError`).
+      2. Validate every UUID in `manual_sequence` is a known, non-cancelled, non-complete
+         Job in the tenant (else `ManualSequenceInvalidError`); the new job_id from the URL
+         **must be present exactly once** in `manual_sequence` (else
+         `ManualSequenceInvalidError`).
+      3. Validate `manual_sequence` contains no duplicates.
+      4. Compute totals by calling `routing_service.adapter.optimize_sequence` with the manual
+         sequence to derive `total_distance_m`, `total_duration_s`, per-segment ETAs. Honour
+         the manual order — do not re-optimize.
+    * Common path (transactional):
+      * Open a single DB transaction (`async with session.begin():`).
+      * Look up or create the Route for `(tenant_id, vehicle_id, work_date)`:
+        * If exists with status `committed`: replace its stops atomically (`stop_repo.replace_all`)
+          and update totals; status remains `committed`.
+        * If exists with status `in_progress|complete|cancelled`: refuse with
+          `RouteCommitConflictError`. (You cannot re-dispatch into a route that has already
+          started or ended on the day.)
+        * If exists with status `draft`: same path as `committed` for now (draft is a future
+          handle).
+        * If none exists: create one in status `committed` directly (skip `draft` per the
+          OPEN QUESTION note above).
+      * Update the underlying Job's status to `scheduled` if currently `pending`. If the Job is
+        already `scheduled` or `in_progress`, leave its status alone — but ensure the Route
+        references it. If the Job is `complete|cancelled`, refuse with
+        `RouteCommitConflictError`.
+      * Set `committed_at`, `committed_by_user_id`, `option_kind_applied`.
+      * Emit audit `route.committed` with `{route_id, vehicle_id, work_date, option_kind,
+        job_ids: [...], total_distance_m, total_duration_s, manual: bool}`.
+      * Return the route with embedded stops.
+    * Idempotency: a client retrying the same dispatch must not duplicate stops. The
+      `(route_id, job_id)` unique index plus the `replace_all` semantics guarantee this; we
+      also add a soft idempotency check at the service: if the requested manual_sequence (or
+      computed sequence from option_kind) **equals** the existing route's job_ids in order,
+      return the existing route as-is without writes.
+  * `async def cancel_route(tenant_id, user_id, route_id, *, reason: str) -> Route`:
+    * Guards transition via `can_route_transition`.
+    * Sets all non-terminal stops to `skipped`.
+    * Returns the route. Emits audit `route.cancelled` with `{route_id, reason,
+      affected_stop_count}`.
+    * **Does not** cancel the underlying Jobs (they return to `pending` from `scheduled`).
+      The service issues `job_service.transition_route_cancelled(job_id)` for each affected
+      stop — a new method we add to `JobService` for this slice:
+      `async def transition_route_cancelled(tenant_id, user_id, job_id) -> Job` — only legal
+      from `scheduled`; moves Job back to `pending`; emits `job.route_cancelled` audit. If the
+      Job is `in_progress` we leave it as-is.
+  * `async def mark_stop_arrived(tenant_id, user_id, stop_id) -> RouteStop`.
+  * `async def mark_stop_complete(tenant_id, user_id, stop_id) -> RouteStop`:
+    * Stop transition `pending|arrived → complete`. Emits `route.stop_completed`.
+    * After commit, if all stops on the route are terminal, transitions the Route to `complete`
+      (audit `route.completed`).
+  * `async def mark_stop_skipped(tenant_id, user_id, stop_id, reason: str) -> RouteStop`:
+    * Same terminal-check.
+  * `async def start_route(tenant_id, user_id, route_id) -> Route`:
+    * Transition `committed → in_progress`. Sets `started_at = now()`.
+    * Emits `route.started`.
+    * Side effect: `job_service.start(first_unstarted_job)` is **not** called here; technician
+      starts individual jobs explicitly. `route.started` is a route-level handle (used by
+      Slice 16 dynamic re-routing).
+* Create `src/office_hero/api/schemas/dispatch.py`:
+  * `DispatchCommitRequest`:
+    * `date: date` (REQUIRED).
+    * `option_kind: Literal["nearest","earliest","balanced"] | None`.
+    * `manual_vehicle_id: UUID | None`.
+    * `manual_sequence: list[UUID] | None`.
+    * `notes: str | None` (≤2048).
+    * Model validator: **exactly one** of `option_kind` OR `(manual_vehicle_id +
+      manual_sequence)` must be provided. If both or neither, return 422 with a structured
+      message.
+    * `model_config = ConfigDict(extra="forbid")`.
+* Create `src/office_hero/api/schemas/route.py`:
+  * `RouteStopRead`: `{id, job_id, sequence_index, status, planned_eta, actual_arrived_at,
+    actual_completed_at, planned_distance_from_prev_m, planned_duration_from_prev_s,
+    job: JobSummary}`.
+  * `RouteRead`: `{id, vehicle_id, vehicle_crew_id, work_date, status, committed_at,
+    started_at, completed_at, cancelled_at, cancel_reason, total_distance_m,
+    total_duration_s, option_kind_applied, committed_by_user_id, notes,
+    stops: list[RouteStopRead], vehicle: VehicleSummary, crew: VehicleCrewSummary}`.
+  * `RouteListResponse`: `{items: list[RouteRead], total: int}`.
+  * `RouteCancelRequest`: `{reason: str}` (3..512).
+  * `StopSkipRequest`: `{reason: str}` (3..512).
+* Create `src/office_hero/api/routes/dispatch.py`:
+  * `POST /jobs/{job_id}/dispatch` — `@require_permission("jobs:dispatch")`. Body
+    `DispatchCommitRequest`. Returns 201 with `RouteRead` (whether new or updated). Rate-limit
+    `write` tier 60 req/min.
+* Create `src/office_hero/api/routes/routes.py` — `prefix="/routes"`, `tags=["routes"]`:
+  * `GET /routes` — `@require_permission("routes:read")`. Query params:
+    * `date: ISO date` (required).
+    * `vehicle_id: UUID | None`.
+    * `status: list[str] | None` (multi-select).
+    * `user_id: UUID | None` (Dispatcher/Admin only — Technician role auto-filters to self).
+    * Default sort: `(vehicle.nickname, vehicle.license_plate, sequence_index)`.
+  * `GET /routes/{id}` — `@require_permission("routes:read")`. Technicians may only read
+    routes whose crew they are a member of (service enforces; mismatch returns 404, not 403,
+    to avoid leaking existence).
+  * `POST /routes/{id}/start` — `@require_role([Dispatcher, TenantAdmin, Operator, Technician,
+    TechnicianHelper])`. Service further restricts: Technicians can only start a route they're
+    on.
+  * `POST /routes/{id}/cancel` — `@require_role([Dispatcher, TenantAdmin, Operator])`. Body
+    `RouteCancelRequest`.
+  * `POST /routes/{id}/stops/{stop_id}/arrived` —
+    `@require_role([Technician, TechnicianHelper, Dispatcher, TenantAdmin, Operator])`.
+  * `POST /routes/{id}/stops/{stop_id}/complete` — same role gate; service auto-finalises the
+    Route on all-stops-terminal.
+  * `POST /routes/{id}/stops/{stop_id}/skip` — same; body `StopSkipRequest`.
+* Update `src/office_hero/api/state.py`:
+  * `get_route_repository()`, `get_route_stop_repository()`, `get_dispatch_service()`.
+* Register routers in `src/office_hero/api/app.py`.
+* Update `src/office_hero/api/exception_handlers.py`:
+  * `RouteNotFoundError` → 404.
+  * `InvalidRouteTransitionError` → 422 with `{from, to}`.
+  * `RouteCommitConflictError` → 409 with `{detail, reason}`.
+  * `ManualSequenceInvalidError` → 422 with `{detail, errors: [...]}`.
+* Update `JobService` (from slice 012):
+  * Add `async def transition_route_cancelled(tenant_id, user_id, job_id) -> Job` — moves
+    scheduled jobs back to pending when their route is cancelled.
+  * Already-defined `JobService.schedule` is the path used inside the dispatch transaction.
+    Service is responsible for ensuring the call is idempotent (no-op if Job is already
+    scheduled).
+* Create migration `alembic/versions/0007_routes.py`:
+  * Create `routes` table; columns per model; FKs to `tenants`, `vehicles`, `vehicle_crews`,
+    `users`.
+  * Unique `uq_route_tenant_vehicle_date` ON `(tenant_id, vehicle_id, work_date)`.
+  * Indexes: `(tenant_id, work_date)`, `(tenant_id, status)`.
+  * CHECK `status IN ('draft','committed','in_progress','complete','cancelled')`.
+  * RLS enable + `route_tenant_isolation` policy.
+  * Create `route_stops` table; FKs `tenants`, `routes (ON DELETE CASCADE)`, `jobs`.
+  * Unique `(route_id, sequence_index)`; unique `(route_id, job_id)`.
+  * Index `(tenant_id, route_id)`.
+  * CHECK `status IN ('pending','arrived','complete','skipped')`.
+  * RLS enable + policy.
+  * Downgrade drops policies, tables in reverse.
+* Unit tests `tests/unit/test_dispatch_service.py`:
+  * `test_commit_dispatch_option_kind_creates_route_and_stops`
+  * `test_commit_dispatch_manual_mode_creates_route_with_exact_sequence`
+  * `test_commit_dispatch_requires_option_or_manual` (both/neither → 422)
+  * `test_commit_dispatch_manual_sequence_must_include_target_job`
+  * `test_commit_dispatch_manual_sequence_rejects_duplicates`
+  * `test_commit_dispatch_manual_vehicle_without_crew_on_date_409`
+  * `test_commit_dispatch_target_job_complete_409`
+  * `test_commit_dispatch_target_job_cancelled_409`
+  * `test_commit_dispatch_existing_in_progress_route_409`
+  * `test_commit_dispatch_existing_committed_route_replaces_stops_atomically`
+  * `test_commit_dispatch_idempotent_when_sequence_unchanged`
+  * `test_commit_dispatch_sets_job_status_to_scheduled`
+  * `test_commit_dispatch_audit_event_emitted_with_ids_and_totals`
+  * `test_cancel_route_marks_non_terminal_stops_skipped`
+  * `test_cancel_route_returns_scheduled_jobs_to_pending`
+  * `test_cancel_route_does_not_revert_in_progress_jobs`
+  * `test_start_route_transitions_committed_to_in_progress`
+  * `test_start_route_from_complete_raises_invalid_transition`
+  * `test_complete_last_stop_finalises_route_to_complete`
+  * `test_skip_stop_with_other_pending_stops_keeps_route_in_progress`
+  * `test_arrive_then_complete_stop_sets_actual_timestamps`
+* Unit tests `tests/unit/test_route_status.py`:
+  * Parameterised transition matrix tests for both route and stop status enums.
+* API tests `tests/api/test_dispatch_api.py`:
+  * `test_post_dispatch_requires_jobs_dispatch_permission` (Technician 403)
+  * `test_post_dispatch_with_option_kind_201_returns_route`
+  * `test_post_dispatch_with_manual_sequence_201_returns_route`
+  * `test_post_dispatch_with_both_modes_422`
+  * `test_post_dispatch_with_neither_mode_422`
+  * `test_post_dispatch_cross_tenant_job_404`
+  * `test_post_dispatch_completed_job_409`
+  * `test_post_dispatch_rate_limited_60_per_min`
+  * `test_post_dispatch_idempotent_replay_returns_same_route_no_dup_stops`
+* API tests `tests/api/test_routes_api.py`:
+  * `test_get_routes_date_required_422_when_missing`
+  * `test_get_routes_dispatcher_sees_all_for_date`
+  * `test_get_routes_technician_sees_only_own_crew_routes`
+  * `test_get_route_by_id_includes_ordered_stops_and_job_summaries`
+  * `test_get_route_cross_tenant_404`
+  * `test_post_route_start_dispatcher_succeeds`
+  * `test_post_route_start_technician_not_on_crew_404`
+  * `test_post_route_cancel_dispatcher_succeeds`
+  * `test_post_route_cancel_technician_403`
+  * `test_post_stop_arrived_technician_succeeds`
+  * `test_post_stop_complete_auto_finalises_route_when_last`
+  * `test_post_stop_skip_with_reason_succeeds`
+* Integration test `tests/integration/test_dispatch_transaction.py`:
+  * `test_dispatch_commit_is_atomic_under_concurrent_calls` — two threads concurrently dispatch
+    different jobs to the *same* vehicle for the same day; both must succeed (route gets two
+    stops) without violating `(route_id, sequence_index)` invariant. Uses
+    `SELECT ... FOR UPDATE` on the Route row inside the service to serialise.
+  * `test_dispatch_commit_rolls_back_on_routing_engine_failure` — force the routing adapter
+    to raise after the Route row is inserted; assert no Route row remains (full rollback).
+  * `test_rls_hides_other_tenant_routes`
+* Integration test `tests/integration/test_route_lifecycle.py`:
+  * End-to-end: create customer + location + job + vehicle + crew; dispatch with `nearest`;
+    start route; mark stop arrived; mark stop complete; assert route auto-finalises.
+
+## Structure
+
+```text
+src/office_hero/
+├── core/
+│   ├── exceptions.py            # +RouteNotFoundError, +InvalidRouteTransitionError,
+│   │                            #  +RouteCommitConflictError, +ManualSequenceInvalidError
+│   └── route_status.py          # RouteStatus + RouteStopStatus enums + transition matrices
+├── models/
+│   └── route.py                 # Route + RouteStop
+├── repositories/
+│   ├── route_repository.py
+│   └── route_stop_repository.py
+├── services/
+│   ├── dispatch_service.py
+│   └── job_service.py           # +transition_route_cancelled()
+└── api/
+    ├── schemas/
+    │   ├── dispatch.py
+    │   └── route.py
+    └── routes/
+        ├── dispatch.py
+        └── routes.py
+
+alembic/
+└── versions/
+    └── 0007_routes.py
+
+tests/
+├── unit/
+│   ├── test_dispatch_service.py
+│   └── test_route_status.py
+├── api/
+│   ├── test_dispatch_api.py
+│   └── test_routes_api.py
+└── integration/
+    ├── test_dispatch_transaction.py
+    └── test_route_lifecycle.py
+```
+
+## Failing Test Outline
+
+```python
+# tests/unit/test_dispatch_service.py
+import pytest
+from datetime import date
+from office_hero.core.exceptions import (
+    RouteCommitConflictError, ManualSequenceInvalidError,
+)
+
+
+@pytest.mark.asyncio
+async def test_commit_dispatch_existing_committed_route_replaces_stops_atomically(
+    dispatch_service, scheduled_job_a, scheduled_job_b, vehicle, crew, dispatcher_user
+):
+    """Re-dispatch to the same vehicle replaces stops without duplicating."""
+    # First dispatch — vehicle gets job_a as its only stop.
+    r1 = await dispatch_service.commit_dispatch(
+        TENANT_A, dispatcher_user.id, job_id=scheduled_job_a.id,
+        payload=manual_payload(date(2026, 6, 1), vehicle.id, [scheduled_job_a.id]),
+    )
+    assert [s.job_id for s in r1.stops] == [scheduled_job_a.id]
+
+    # Second dispatch — same vehicle, both jobs in sequence.
+    r2 = await dispatch_service.commit_dispatch(
+        TENANT_A, dispatcher_user.id, job_id=scheduled_job_b.id,
+        payload=manual_payload(date(2026, 6, 1), vehicle.id,
+                               [scheduled_job_a.id, scheduled_job_b.id]),
+    )
+    assert r1.id == r2.id
+    assert [s.job_id for s in r2.stops] == [scheduled_job_a.id, scheduled_job_b.id]
+    assert len(r2.stops) == 2  # no duplicates
+
+
+@pytest.mark.asyncio
+async def test_commit_dispatch_manual_sequence_rejects_duplicates(
+    dispatch_service, scheduled_job_a, vehicle, dispatcher_user
+):
+    """Manual sequence with duplicate job_ids is rejected."""
+    with pytest.raises(ManualSequenceInvalidError):
+        await dispatch_service.commit_dispatch(
+            TENANT_A, dispatcher_user.id, job_id=scheduled_job_a.id,
+            payload=manual_payload(
+                date(2026, 6, 1), vehicle.id,
+                [scheduled_job_a.id, scheduled_job_a.id],
+            ),
+        )
+
+
+# tests/integration/test_dispatch_transaction.py
+@pytest.mark.asyncio
+async def test_dispatch_commit_is_atomic_under_concurrent_calls(
+    integration_session, dispatch_service, scheduled_job_a, scheduled_job_b,
+    vehicle, dispatcher_user
+):
+    """Two concurrent dispatches to the same vehicle serialise correctly."""
+    async def dispatch_a():
+        return await dispatch_service.commit_dispatch(
+            TENANT_A, dispatcher_user.id, job_id=scheduled_job_a.id,
+            payload=manual_payload(date(2026, 6, 1), vehicle.id, [scheduled_job_a.id]),
+        )
+
+    async def dispatch_b():
+        return await dispatch_service.commit_dispatch(
+            TENANT_A, dispatcher_user.id, job_id=scheduled_job_b.id,
+            payload=manual_payload(date(2026, 6, 1), vehicle.id, [scheduled_job_b.id]),
+        )
+
+    import asyncio
+    results = await asyncio.gather(dispatch_a(), dispatch_b())
+    final_route = await dispatch_service.get_route_for_vehicle_date(
+        TENANT_A, vehicle.id, date(2026, 6, 1),
+    )
+    job_ids = {s.job_id for s in final_route.stops}
+    assert job_ids == {scheduled_job_a.id, scheduled_job_b.id}
+```
+
+## Dependencies
+
+* **Slice 2 (Database foundation)** — async engine, RLS, Alembic, transaction primitives.
+* **Slice 3 (Auth & RBAC)** — JWT, decorators, Role enum.
+* **Slice 4 (Observability)** — `AuditService`, exception handler integration, rate limiting.
+* **Slice 7 (Tenant management)** — tenants table for FKs.
+* **Slice 11 (Customer & Location)** — Location for stop ETA computation.
+* **Slice 12 (Job management)** — Job status lifecycle; `JobService.schedule`,
+  `transition_route_cancelled` (added in this slice on the same JobService class).
+* **Slice 13 (Vehicle & VehicleCrew)** — Vehicle, VehicleCrew; FK references.
+* **Slice 14 / Design 014 (Routing engine)** — `RoutingService.compute_options` for option
+  mode; `routing_service.adapter.optimize_sequence` for manual-mode totals.
+* Relevant ADRs: **053** (RLS), **056** (saga/outbox — *not* used here because dispatch is
+  all local DB; back-office push of route/dispatch info to ServiceTitan/PestPac is Slice 25+),
+  **058**, **059**, **060**, **062** (write tier; routing tier from slice 14), **063**
+  (audit + structured logs).
+
+## Effort
+
+Estimate: **3/5**. Two tables, two services (one extended), two routers, but the transactional
+correctness in `commit_dispatch` carries weight: atomic replace-all of stops, idempotent retry,
+Job status side effects all inside one transaction, plus the manual-mode validation matrix.
+Concurrency under same-vehicle-same-day is non-trivial — `SELECT ... FOR UPDATE` on the Route
+row is the cleanest serialisation hook and is tested. The route auto-finalisation on
+all-stops-terminal is a subtle invariant; centralised in `dispatch_service` and tested.
+
+## Risk Callouts
+
+* **Transactional atomicity.** `commit_dispatch` mutates Route + RouteStops + Jobs in one
+  transaction. Any partial failure must roll back the whole thing. Tested with deliberate
+  routing-adapter failures injected mid-transaction. **Important:** the call to
+  `routing_service.adapter.optimize_sequence` happens *before* the DB writes so a network
+  failure cannot corrupt half-committed state. Reviewers should reject any refactor that
+  reorders those steps.
+* **Stale options.** Option mode re-fetches options instead of trusting client-supplied
+  vehicle_id, because the underlying world may have changed since the
+  `/jobs/{id}/routing-options` call. **OPEN QUESTION:** stakeholders may prefer trusting the
+  client's already-shown choice (UX argument); flagged in PR. Default is re-fetch.
+* **Concurrency on same vehicle + date.** Two simultaneous dispatches to the same vehicle/day
+  must not corrupt sequence indices. Service uses `SELECT ... FOR UPDATE` on the Route row
+  (creating it inside the same lock if absent) so calls serialise. The unique
+  `(route_id, sequence_index)` index is a backstop.
+* **Re-dispatch into in_progress route.** Refused with 409. Re-dispatching a single new Job
+  to a vehicle whose route is *committed but not started* is the common case and is the
+  primary code path under test.
+* **Route cancellation cascade.** Cancelling a route reverts `scheduled` jobs to `pending`
+  but does not touch `in_progress` jobs. Tested. The cascade emits one audit event per affected
+  job; reviewers should consider whether that is too chatty for very large routes (low risk;
+  routes are bounded to ≤50 stops via `ROUTING_MAX_STOPS_PER_OPTIMIZE` in slice 014).
+* **No back-office push yet.** Slice 25+ will use the `outbox_events` table to push committed
+  routes to ServiceTitan etc. via the Saga pattern (ADR 056). This slice writes nothing to
+  `outbox_events` — that's a follow-up. Documented in the service docstring.
+* **Idempotency without idem keys.** True idempotency comes from the `(route_id, job_id)`
+  uniqueness on RouteStops plus the "sequence unchanged → no-op" guard. Clients should still
+  use a request ID in the audit log for traceability.
+* **RLS hides vs 403.** Per the auth slice pattern, RLS hides cross-tenant rows; we return
+  404, not 403, to avoid leaking existence. Same applies to Technicians querying routes they
+  are not assigned to. Tests assert 404 consistently.
+
+---
+
+Once approved, implementation proceeds: model + migration first, then `route_status.py` matrix
++ tests, then `DispatchService.commit_dispatch` under TDD (with the routing service stubbed),
+then the route-lifecycle methods, then routers. The concurrency integration test is gated on
+a Neon branch; reviewers should run it manually before merge.


### PR DESCRIPTION
## Summary

Five Phase-4 slice design documents for the core FSM feature slices that Wave 2 implementation will pick up. Rescued from a session-interrupted Phase 4 agent — the docs were written but never committed.

| File                                  | Master slice plan       | Lines |
|---------------------------------------|-------------------------|-------|
| 011-slice.customer-location.md        | Slice 9                 | 408   |
| 012-slice.job-management.md           | Slice 10                | 421   |
| 013-slice.vehicle-vehiclecrew.md      | Slice 12                | 418   |
| 014-slice.routing-engine.md           | Slice 13                | 446   |
| 015-slice.dispatch-route.md           | Slice 14                | 544   |
| **Total**                             |                         | **2,237** |

Each doc follows the pattern of `006-slice.auth-rbac.md`: YAML frontmatter, Goals (file-by-file), Structure (directory tree), Failing tests (TDD list), Dependencies, Effort.

## Key design choices baked in

- **Tenant isolation:** every new table has `tenant_id` + RLS policy (per ADR 053)
- **RBAC:** every state-changing endpoint uses `@require_role` / `@require_permission` (per ADR 060)
- **Geocoding (Slice 9):** pluggable `GeocodingAdapter` protocol; v1 default = Nominatim (free, no API key), ORS adapter for future swap
- **Custom fields (Slice 10):** per-industry JSONB templates (plumbing / HVAC / pest) with schema validation
- **Routing (Slice 13):** `RoutingAdapter` protocol; `ORSRoutingAdapter` HTTP client with SSRF allowlist; `POST /jobs/{id}/routing-options` returns three ranked options
- **Dispatch (Slice 14):** single-transaction Route + RouteStops creation; status lifecycle draft → committed → in_progress → complete

## Open design questions (to resolve before implementation)

- Each doc lists open design questions explicitly. Highlights:
  - Slice 13: how to handle ORS rate limits (cache? distance matrix?)
  - Slice 14: should manual dispatch reuse the routing engine's distance calc or skip it?

## Next step after merge

Wave 2 implementation can dispatch worker agents per slice. The orchestrator routine (#56 or its dashboard) will start picking these up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)