### PR TITLE
docs(slice 14): unbreak markdownlint MD032 on line continuation

### DIFF
--- a/project-documents/user/slices/015-slice.dispatch-route.md
+++ b/project-documents/user/slices/015-slice.dispatch-route.md
@@ -538,7 +538,7 @@ all-stops-terminal is a subtle invariant; centralised in `dispatch_service` and 
 
 ---
 
-Once approved, implementation proceeds: model + migration first, then `route_status.py` matrix
-+ tests, then `DispatchService.commit_dispatch` under TDD (with the routing service stubbed),
-then the route-lifecycle methods, then routers. The concurrency integration test is gated on
-a Neon branch; reviewers should run it manually before merge.
+Once approved, implementation proceeds: model + migration first, then the `route_status.py`
+matrix and its tests, then `DispatchService.commit_dispatch` under TDD (with the routing
+service stubbed), then the route-lifecycle methods, then routers. The concurrency
+integration test is gated on a Neon branch; reviewers should run it manually before merge.


### PR DESCRIPTION
Tiny one-paragraph rewrap in `project-documents/user/slices/015-slice.dispatch-route.md`. The wrapped line that started with `+ tests` was being parsed by markdownlint as a list item, breaking CI on every downstream PR (caught while merging PR #55 — see https://github.com/jakez-gh/benj-office-hero/actions/runs/26427638384). Pure docs change; no semantic difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)