### PR TITLE
feat(slice 9): Customer & Location management

### DIFF
--- a/alembic/versions/0004_customers_and_locations.py
+++ b/alembic/versions/0004_customers_and_locations.py
@@ -1,0 +1,182 @@
+"""customers and locations tables with RLS and trigram search
+
+Revision ID: 0004_customers_and_locations
+Revises: 0003_rate_limits_audit_events
+Create Date: 2026-05-27 00:00:00.000000
+
+Adds the Customer and Location aggregates for Slice 9 (Customer & Location
+management). Includes:
+
+  * ``customers`` and ``locations`` tables with FKs to ``tenants(id)``
+  * unique partial index on ``(tenant_id, lower(email))`` (email scoped per
+    tenant, active rows only)
+  * GIN trigram index on ``customers.name`` for substring search
+  * indexes on ``(tenant_id, customer_id)`` and ``(tenant_id, geocode_status)``
+    so the geocoding worker can find pending rows quickly
+  * RLS policies pinning row visibility to ``current_setting('app.tenant_id')``
+    (ADR 053)
+
+Extensions ``citext`` (case-insensitive email) and ``pg_trgm`` (trigram search)
+are created with ``IF NOT EXISTS`` so reruns/replays are safe.
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0004_customers_and_locations"
+down_revision = "0003_rate_limits_audit_events"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # PostgreSQL extensions used by the indexes below.
+    op.execute("CREATE EXTENSION IF NOT EXISTS citext;")
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm;")
+
+    # --- customers ---
+    op.create_table(
+        "customers",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("tenant_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        # ``email`` is plain VARCHAR here; PostgreSQL CITEXT would simplify
+        # case-insensitivity but increases swap cost (ADR 059). Instead we
+        # enforce case-insensitive uniqueness via a partial functional index
+        # on ``lower(email)`` below.
+        sa.Column("email", sa.String(length=255), nullable=True),
+        sa.Column("phone", sa.String(length=50), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column(
+            "archived", sa.Boolean(), nullable=False, server_default=sa.false()
+        ),
+        sa.Column("external_id", sa.String(length=255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"]),
+    )
+
+    # Unique active email per tenant (case-insensitive). NULL emails are
+    # allowed (partial index excludes them).
+    op.execute(
+        """
+        CREATE UNIQUE INDEX uq_customer_tenant_email_active
+            ON customers (tenant_id, lower(email))
+            WHERE email IS NOT NULL AND archived = false;
+        """
+    )
+
+    # Trigram GIN for fast ILIKE-style search on customer name.
+    op.execute(
+        """
+        CREATE INDEX idx_customer_name_trgm
+            ON customers USING GIN (name gin_trgm_ops);
+        """
+    )
+
+    op.execute(
+        """
+        ALTER TABLE customers ENABLE ROW LEVEL SECURITY;
+        CREATE POLICY customer_tenant_isolation ON customers
+            USING (tenant_id = current_setting('app.tenant_id')::uuid);
+        """
+    )
+
+    # --- locations ---
+    op.create_table(
+        "locations",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("tenant_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("customer_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("label", sa.String(length=255), nullable=True),
+        sa.Column("street", sa.String(length=255), nullable=False),
+        sa.Column("street2", sa.String(length=255), nullable=True),
+        sa.Column("city", sa.String(length=120), nullable=False),
+        sa.Column("state", sa.String(length=60), nullable=False),
+        sa.Column("postal_code", sa.String(length=20), nullable=False),
+        sa.Column(
+            "country",
+            sa.String(length=2),
+            nullable=False,
+            server_default="US",
+        ),
+        sa.Column("lat", sa.Numeric(precision=9, scale=6), nullable=True),
+        sa.Column("lng", sa.Numeric(precision=9, scale=6), nullable=True),
+        sa.Column("geocode_source", sa.String(length=50), nullable=True),
+        sa.Column(
+            "geocode_status",
+            sa.String(length=20),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column("geocoded_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "archived", sa.Boolean(), nullable=False, server_default=sa.false()
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"]),
+        sa.ForeignKeyConstraint(["customer_id"], ["customers.id"], ondelete="CASCADE"),
+    )
+
+    op.create_index(
+        "idx_location_tenant_customer",
+        "locations",
+        ["tenant_id", "customer_id"],
+    )
+    op.create_index(
+        "idx_location_tenant_status",
+        "locations",
+        ["tenant_id", "geocode_status"],
+    )
+
+    op.execute(
+        """
+        ALTER TABLE locations ENABLE ROW LEVEL SECURITY;
+        CREATE POLICY location_tenant_isolation ON locations
+            USING (tenant_id = current_setting('app.tenant_id')::uuid);
+        """
+    )
+
+
+def downgrade() -> None:
+    # --- locations ---
+    op.execute("DROP POLICY IF EXISTS location_tenant_isolation ON locations;")
+    op.execute("ALTER TABLE locations DISABLE ROW LEVEL SECURITY;")
+    op.drop_index("idx_location_tenant_status", table_name="locations")
+    op.drop_index("idx_location_tenant_customer", table_name="locations")
+    op.drop_table("locations")
+
+    # --- customers ---
+    op.execute("DROP POLICY IF EXISTS customer_tenant_isolation ON customers;")
+    op.execute("ALTER TABLE customers DISABLE ROW LEVEL SECURITY;")
+    op.execute("DROP INDEX IF EXISTS idx_customer_name_trgm;")
+    op.execute("DROP INDEX IF EXISTS uq_customer_tenant_email_active;")
+    op.drop_table("customers")
+
+    # We deliberately do NOT drop the citext/pg_trgm extensions on downgrade —
+    # other migrations / tables may use them and dropping a PostgreSQL
+    # extension cascades into any objects that reference it.

--- a/alembic/versions/0004_customers_and_locations.py
+++ b/alembic/versions/0004_customers_and_locations.py
@@ -50,9 +50,7 @@ def upgrade() -> None:
         sa.Column("email", sa.String(length=255), nullable=True),
         sa.Column("phone", sa.String(length=50), nullable=True),
         sa.Column("notes", sa.Text(), nullable=True),
-        sa.Column(
-            "archived", sa.Boolean(), nullable=False, server_default=sa.false()
-        ),
+        sa.Column("archived", sa.Boolean(), nullable=False, server_default=sa.false()),
         sa.Column("external_id", sa.String(length=255), nullable=True),
         sa.Column(
             "created_at",
@@ -123,9 +121,7 @@ def upgrade() -> None:
             server_default="pending",
         ),
         sa.Column("geocoded_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column(
-            "archived", sa.Boolean(), nullable=False, server_default=sa.false()
-        ),
+        sa.Column("archived", sa.Boolean(), nullable=False, server_default=sa.false()),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),

--- a/src/office_hero/adapters/geocoding/__init__.py
+++ b/src/office_hero/adapters/geocoding/__init__.py
@@ -1,0 +1,1 @@
+"""Geocoding adapter family (protocol + Nominatim default + future ORS)."""

--- a/src/office_hero/adapters/geocoding/factory.py
+++ b/src/office_hero/adapters/geocoding/factory.py
@@ -1,0 +1,44 @@
+"""Factory for building a :class:`GeocodingAdapter` from :class:`Settings`."""
+
+from __future__ import annotations
+
+import os
+
+from office_hero.adapters.geocoding.nominatim import NominatimGeocodingAdapter
+from office_hero.adapters.geocoding.ors import ORSGeocodingAdapter
+from office_hero.adapters.geocoding.protocol import GeocodingAdapter
+from office_hero.adapters.geocoding.stub import StubGeocodingAdapter
+from office_hero.core.config import Settings
+
+
+def build_geocoding_adapter(settings: Settings) -> GeocodingAdapter:
+    """Build a concrete adapter from ``settings.geocoding_adapter``.
+
+    Under ``pytest`` (detected via ``PYTEST_CURRENT_TEST``) the stub adapter is
+    returned by default to keep CI off the live Nominatim network. Tests that
+    need to exercise a real adapter set ``settings.geocoding_adapter`` explicitly
+    to ``"nominatim"`` / ``"ors"`` (and accept the test runs through that path).
+    """
+    choice = (settings.geocoding_adapter or "nominatim").lower()
+
+    if choice == "stub":
+        return StubGeocodingAdapter()
+
+    if os.environ.get("PYTEST_CURRENT_TEST") and choice == "nominatim":
+        # CI safety net: never call the live Nominatim service unless an
+        # operator explicitly opts in via ``geocoding_adapter="ors"`` or
+        # ``"stub"``.
+        return StubGeocodingAdapter()
+
+    if choice == "nominatim":
+        return NominatimGeocodingAdapter(
+            base_url=settings.nominatim_base_url,
+            user_agent=settings.nominatim_user_agent,
+            timeout=settings.geocoding_timeout_s,
+            allowlist=settings.geocoding_allowlist,
+        )
+
+    if choice == "ors":
+        return ORSGeocodingAdapter()
+
+    raise ValueError(f"Unknown geocoding_adapter: {choice!r}")

--- a/src/office_hero/adapters/geocoding/nominatim.py
+++ b/src/office_hero/adapters/geocoding/nominatim.py
@@ -72,9 +72,7 @@ class NominatimGeocodingAdapter(GeocodingAdapter):
         if allowlist is not None:
             host = urlparse(base_url).hostname or ""
             if host not in set(allowlist):
-                raise GeocodingError(
-                    f"Refusing to geocode against host '{host}': not in allowlist"
-                )
+                raise GeocodingError(f"Refusing to geocode against host '{host}': not in allowlist")
 
         self._base_url = base_url.rstrip("/")
         self._user_agent = user_agent

--- a/src/office_hero/adapters/geocoding/nominatim.py
+++ b/src/office_hero/adapters/geocoding/nominatim.py
@@ -1,0 +1,175 @@
+"""NominatimGeocodingAdapter — production-default address-to-coordinate resolver.
+
+This adapter calls the public Nominatim service operated by OpenStreetMap
+(https://nominatim.org/release-docs/develop/api/Search/). Nominatim's usage
+policy mandates:
+
+  * a real, identifying ``User-Agent`` header (anonymous traffic is throttled
+    aggressively);
+  * a sustained request rate not exceeding **1 request per second** per source
+    IP/identity.
+
+The adapter enforces both: the ``User-Agent`` is required at construction
+time (via ``Settings.nominatim_user_agent``), and an ``asyncio.Semaphore(1)``
+combined with a minimum-interval sleeper ensures we never exceed 1 req/sec.
+
+SSRF defence: the configured ``base_url`` is validated against
+``settings.geocoding_allowlist`` at construction time so an operator cannot
+point the geocoder at an internal IP through configuration.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Iterable
+from urllib.parse import urlparse
+
+import httpx
+
+from office_hero.adapters.geocoding.protocol import (
+    AddressInput,
+    Coordinates,
+    GeocodingAdapter,
+)
+from office_hero.core.exceptions import GeocodingError
+from office_hero.core.logging import get_logger
+
+log = get_logger(__name__)
+
+
+class NominatimGeocodingAdapter(GeocodingAdapter):
+    """Production Nominatim adapter (1 req/sec, ToS-compliant)."""
+
+    SOURCE: str = "nominatim"
+    MIN_INTERVAL_S: float = 1.0  # Nominatim ToS hard ceiling.
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        user_agent: str,
+        timeout: float = 5.0,
+        allowlist: Iterable[str] | None = None,
+        client: httpx.AsyncClient | None = None,
+    ):
+        """Construct an adapter and validate the base_url against the allowlist.
+
+        Args:
+            base_url: Nominatim root URL, e.g. ``"https://nominatim.openstreetmap.org"``.
+            user_agent: Identifying User-Agent header (Nominatim ToS).
+            timeout: Per-request timeout in seconds.
+            allowlist: Iterable of allowed hostnames. ``None`` disables the check
+                (useful only for tests that build the adapter against a mock host).
+            client: Optional pre-built ``httpx.AsyncClient`` (mainly for tests).
+
+        Raises:
+            GeocodingError: If ``base_url``'s host is not in ``allowlist``.
+        """
+        if not user_agent:
+            raise GeocodingError("Nominatim requires a non-empty user_agent (ToS)")
+
+        if allowlist is not None:
+            host = urlparse(base_url).hostname or ""
+            if host not in set(allowlist):
+                raise GeocodingError(
+                    f"Refusing to geocode against host '{host}': not in allowlist"
+                )
+
+        self._base_url = base_url.rstrip("/")
+        self._user_agent = user_agent
+        self._timeout = timeout
+        self._client = client
+        self._owns_client = client is None
+
+        # Rate-limit gate: one request at a time AND >=1s gap between dispatches.
+        self._semaphore = asyncio.Semaphore(1)
+        self._last_dispatch_monotonic: float = 0.0
+
+    async def geocode(self, address: AddressInput) -> Coordinates | None:
+        """Resolve an :class:`AddressInput` via Nominatim ``/search``.
+
+        Returns the first matching candidate's ``lat``/``lng`` or ``None`` when
+        Nominatim reports no results.
+
+        Raises:
+            GeocodingError: On HTTP error, timeout, or response parse failure.
+        """
+        query = ", ".join(
+            part
+            for part in (
+                address.street,
+                address.city,
+                address.state,
+                address.postal_code,
+                address.country,
+            )
+            if part
+        )
+
+        params = {"format": "jsonv2", "q": query, "limit": "1"}
+        headers = {"User-Agent": self._user_agent}
+        url = f"{self._base_url}/search"
+
+        async with self._semaphore:
+            # Sleep until at least MIN_INTERVAL_S has elapsed since the last call.
+            now = time.monotonic()
+            wait = self.MIN_INTERVAL_S - (now - self._last_dispatch_monotonic)
+            if wait > 0:
+                await asyncio.sleep(wait)
+            self._last_dispatch_monotonic = time.monotonic()
+
+            try:
+                client = self._client or httpx.AsyncClient(timeout=self._timeout)
+                try:
+                    resp = await client.get(url, params=params, headers=headers)
+                finally:
+                    if self._owns_client and self._client is None:
+                        await client.aclose()
+            except httpx.TimeoutException as exc:
+                log.warning(
+                    "geocoding.nominatim.timeout",
+                    error=str(exc),
+                    query=query,
+                )
+                raise GeocodingError(f"Nominatim timed out: {exc}") from exc
+            except httpx.HTTPError as exc:
+                log.warning(
+                    "geocoding.nominatim.http_error",
+                    error=str(exc),
+                    query=query,
+                )
+                raise GeocodingError(f"Nominatim HTTP error: {exc}") from exc
+
+        if resp.status_code >= 400:
+            log.warning(
+                "geocoding.nominatim.bad_status",
+                status_code=resp.status_code,
+                query=query,
+            )
+            raise GeocodingError(f"Nominatim returned HTTP {resp.status_code}")
+
+        try:
+            payload = resp.json()
+        except ValueError as exc:
+            log.warning("geocoding.nominatim.bad_json", query=query)
+            raise GeocodingError(f"Nominatim returned non-JSON body: {exc}") from exc
+
+        if not payload:
+            log.info("geocoding.nominatim.miss", query=query)
+            return None
+
+        try:
+            first = payload[0]
+            lat = float(first["lat"])
+            lng = float(first["lon"])
+            display_name = str(first.get("display_name", query))
+        except (KeyError, ValueError, TypeError) as exc:
+            raise GeocodingError(f"Nominatim payload missing lat/lon: {exc}") from exc
+
+        return Coordinates(
+            lat=lat,
+            lng=lng,
+            formatted_address=display_name,
+            source=self.SOURCE,
+        )

--- a/src/office_hero/adapters/geocoding/ors.py
+++ b/src/office_hero/adapters/geocoding/ors.py
@@ -1,0 +1,33 @@
+"""ORSGeocodingAdapter — OpenRouteService geocoder (stubbed, future slice).
+
+Wiring exists so the factory ``settings.geocoding_adapter = "ors"`` switch can
+be exercised by tests, but the actual HTTP integration lands when an
+OpenRouteService API key is provisioned (tracked in a follow-up slice).
+"""
+
+from __future__ import annotations
+
+from office_hero.adapters.geocoding.protocol import (
+    AddressInput,
+    Coordinates,
+    GeocodingAdapter,
+)
+
+
+class ORSGeocodingAdapter(GeocodingAdapter):
+    """Skeleton ORS adapter — raises until the integration is provisioned."""
+
+    SOURCE: str = "ors"
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Accept any kwargs the factory may pass; integration is deferred."""
+        # Intentional no-op: this class exists as a placeholder so the
+        # ``GEOCODING_ADAPTER`` config switch is testable today.
+        return None
+
+    async def geocode(self, address: AddressInput) -> Coordinates | None:
+        """Not implemented — ORS integration is deferred to a follow-up slice."""
+        raise NotImplementedError(
+            "ORSGeocodingAdapter is enabled in a follow-up slice when the ORS "
+            "API key is provisioned."
+        )

--- a/src/office_hero/adapters/geocoding/protocol.py
+++ b/src/office_hero/adapters/geocoding/protocol.py
@@ -1,0 +1,54 @@
+"""GeocodingAdapter protocol + the input/output dataclasses (ADR 058).
+
+The protocol decouples address-to-coordinates resolution from the rest of the
+application so we can swap concrete implementations (Nominatim, ORS, an
+in-memory stub for tests) without rippling changes through the service or
+repository layers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class AddressInput:
+    """Address fields used to query the geocoder.
+
+    Kept intentionally minimal — only the structured pieces a typical geocoder
+    accepts. Free-form address fields (e.g. ``street2``) are deliberately
+    excluded because they confuse most geocoders and rarely affect the result.
+    """
+
+    street: str
+    city: str
+    state: str
+    postal_code: str
+    country: str = "US"
+
+
+@dataclass(frozen=True)
+class Coordinates:
+    """Resolved coordinates returned by a geocoding adapter."""
+
+    lat: float
+    lng: float
+    formatted_address: str
+    source: str
+
+
+@runtime_checkable
+class GeocodingAdapter(Protocol):
+    """Resolve an :class:`AddressInput` to :class:`Coordinates` (or ``None``).
+
+    Implementations must be async; the production default (Nominatim) is
+    network-bound. Implementations should raise
+    :class:`office_hero.core.exceptions.GeocodingError` for hard failures
+    (network, timeout, parse) and return ``None`` when the geocoder responds
+    successfully but returns no candidate.
+    """
+
+    async def geocode(self, address: AddressInput) -> Coordinates | None:
+        """Resolve an address to coordinates, or ``None`` if not resolvable."""
+        ...

--- a/src/office_hero/adapters/geocoding/stub.py
+++ b/src/office_hero/adapters/geocoding/stub.py
@@ -1,0 +1,46 @@
+"""Deterministic stub geocoder for tests (no network, no asyncio sleeps).
+
+Mapping street -> coordinates is hash-derived so a given input always produces
+the same output, which makes service-layer tests easy to assert against.
+"""
+
+from __future__ import annotations
+
+from office_hero.adapters.geocoding.protocol import (
+    AddressInput,
+    Coordinates,
+    GeocodingAdapter,
+)
+
+
+class StubGeocodingAdapter(GeocodingAdapter):
+    """Deterministic geocoder for unit/API tests.
+
+    The output is fully determined by ``address.street`` so tests can pin exact
+    lat/lng values. ``"FAIL"`` anywhere in the street triggers a ``None``
+    return so tests can exercise the not-resolvable code path without
+    monkeypatching.
+    """
+
+    SOURCE: str = "stub"
+
+    async def geocode(self, address: AddressInput) -> Coordinates | None:
+        """Return deterministic coordinates derived from ``address.street``."""
+        if "FAIL" in address.street.upper():
+            return None
+
+        # ``hash`` returns a signed int; mask to a positive range. Using
+        # ``abs`` would lose one possible value but is clearer.
+        seed = abs(hash(address.street))
+        lat = 40.0 + (seed % 1000) / 1000.0  # 40.000 .. 40.999
+        lng = -75.0 - ((seed // 1000) % 1000) / 1000.0  # -75.999 .. -75.000
+
+        formatted = (
+            f"{address.street}, {address.city}, {address.state} {address.postal_code}"
+        )
+        return Coordinates(
+            lat=lat,
+            lng=lng,
+            formatted_address=formatted,
+            source=self.SOURCE,
+        )

--- a/src/office_hero/adapters/geocoding/stub.py
+++ b/src/office_hero/adapters/geocoding/stub.py
@@ -35,9 +35,7 @@ class StubGeocodingAdapter(GeocodingAdapter):
         lat = 40.0 + (seed % 1000) / 1000.0  # 40.000 .. 40.999
         lng = -75.0 - ((seed // 1000) % 1000) / 1000.0  # -75.999 .. -75.000
 
-        formatted = (
-            f"{address.street}, {address.city}, {address.state} {address.postal_code}"
-        )
+        formatted = f"{address.street}, {address.city}, {address.state} {address.postal_code}"
         return Coordinates(
             lat=lat,
             lng=lng,

--- a/src/office_hero/api/app.py
+++ b/src/office_hero/api/app.py
@@ -14,17 +14,38 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from office_hero.adapters.geocoding.stub import StubGeocodingAdapter
 from office_hero.api.exception_handlers import register_exception_handlers
 from office_hero.api.limiter import limiter
 from office_hero.api.middleware.logging import LoggingMiddleware
 from office_hero.api.middleware.security_headers import SecurityHeadersMiddleware
 from office_hero.api.routes import health
 from office_hero.api.routes.admin import audit_router, create_admin_router
+from office_hero.api.routes.customers import create_customer_router
+from office_hero.api.routes.locations import create_location_router
 from office_hero.api.routes.sagas import create_saga_router
-from office_hero.api.state import set_auth_service, set_engine
+from office_hero.api.state import (
+    set_auth_service,
+    set_customer_service,
+    set_engine,
+    set_geocoding_adapter,
+    set_location_service,
+)
 from office_hero.core.logging import get_logger
-from office_hero.repositories.mocks import MockOutboxRepository, MockSagaRepository
+from office_hero.repositories.customer_repository import (
+    InMemoryCustomerRepository,
+)
+from office_hero.repositories.location_repository import (
+    InMemoryLocationRepository,
+)
+from office_hero.repositories.mocks import (
+    InMemoryAuditService,
+    MockOutboxRepository,
+    MockSagaRepository,
+)
 from office_hero.repositories.protocols import OutboxRepository
+from office_hero.services.customer_service import CustomerService
+from office_hero.services.location_service import LocationService
 from office_hero.services.saga_service import SagaService
 
 log = get_logger(__name__)
@@ -79,6 +100,8 @@ def create_app(
     *,
     saga_service: SagaService | None = None,
     outbox_repo: OutboxRepository | None = None,
+    customer_service: CustomerService | None = None,
+    location_service: LocationService | None = None,
 ) -> FastAPI:
     """Create and configure the FastAPI application.
 
@@ -90,14 +113,39 @@ def create_app(
             instance so the module-level ``app`` boots without a database.
         outbox_repo: Outbox repository for dead-letter routes. Defaults to an
             in-memory mock.
+        customer_service: Slice-9 CustomerService. Defaults to an in-memory
+            implementation so tests can construct ``create_app()`` without
+            wiring a DB session.
+        location_service: Slice-9 LocationService (same defaulting behaviour).
 
-    The factory invokes ``create_saga_router`` / ``create_admin_router`` once
-    at startup, not per-request.
+    The factory invokes router factories once at startup, not per-request.
     """
     if saga_service is None:
         saga_service = SagaService(saga_repo=MockSagaRepository())
     if outbox_repo is None:
         outbox_repo = MockOutboxRepository()
+
+    # Slice-9 defaults: in-memory repositories + the stub geocoder. These let
+    # the module-level ``app`` boot without a database and keep API tests off
+    # the live Nominatim service.
+    if customer_service is None or location_service is None:
+        audit = InMemoryAuditService()
+        cust_repo = InMemoryCustomerRepository()
+        loc_repo = InMemoryLocationRepository()
+        geocoder = StubGeocodingAdapter()
+        if customer_service is None:
+            customer_service = CustomerService(repo=cust_repo, audit=audit)
+        if location_service is None:
+            location_service = LocationService(
+                repo=loc_repo,
+                customer_repo=cust_repo,
+                audit=audit,
+                geocoder=geocoder,
+            )
+        set_geocoding_adapter(geocoder)
+
+    set_customer_service(customer_service)
+    set_location_service(location_service)
 
     application = FastAPI(
         title="Office Hero",
@@ -130,6 +178,17 @@ def create_app(
     )
     application.include_router(admin_router, prefix="/admin", tags=["admin"])
     application.include_router(audit_router, prefix="/admin", tags=["admin"])
+
+    customer_router = create_customer_router(
+        service_provider=lambda: customer_service,
+        location_service_provider=lambda: location_service,
+    )
+    application.include_router(customer_router, prefix="/customers", tags=["customers"])
+
+    # The location router carries its own ``/customers/{cid}/locations`` and
+    # ``/locations/{lid}`` paths inline so it mounts at the root.
+    location_router = create_location_router(service_provider=lambda: location_service)
+    application.include_router(location_router, tags=["locations"])
 
     return application
 

--- a/src/office_hero/api/routes/customers.py
+++ b/src/office_hero/api/routes/customers.py
@@ -1,0 +1,227 @@
+"""Customer API routes — CRUD + archive/restore, with RBAC and audit emission.
+
+The router is built via :func:`create_customer_router` so the
+:class:`CustomerService` can be injected at app construction time. Tenant
+isolation relies on ``request.state.tenant_id`` set by the JWT middleware
+(slice 3) and re-checked at the repository / RLS layers.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
+
+from office_hero.api.deps import require_permission, require_role
+from office_hero.api.limiter import limiter
+from office_hero.api.schemas.customer import (
+    CustomerCreate,
+    CustomerList,
+    CustomerRead,
+    CustomerSummary,
+    CustomerUpdate,
+)
+from office_hero.api.schemas.location import LocationRead
+from office_hero.core.exceptions import CustomerNotFoundError
+from office_hero.core.logging import get_logger
+from office_hero.core.roles import Role
+from office_hero.services.customer_service import CustomerService
+
+log = get_logger(__name__)
+
+# Module-level dependency callables. Reused across endpoints so tests can swap
+# them via ``app.dependency_overrides``.
+require_customers_read = require_permission("customers:read")
+require_customers_write = require_permission("customers:write")
+require_customer_admin = require_role(
+    [Role.TenantAdmin, Role.Operator, Role.OperatorStaff]
+)
+
+
+def _tenant_id(request: Request) -> UUID:
+    """Extract tenant_id from request.state; raise 401 if missing."""
+    raw = getattr(request.state, "tenant_id", None)
+    if not raw:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+    return raw if isinstance(raw, UUID) else UUID(str(raw))
+
+
+def _user_id(request: Request) -> UUID:
+    """Extract user_id from request.state for audit attribution."""
+    raw = getattr(request.state, "user_id", None)
+    if not raw:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+    return raw if isinstance(raw, UUID) else UUID(str(raw))
+
+
+def create_customer_router(
+    *,
+    service_provider,
+    location_service_provider=None,
+) -> APIRouter:
+    """Construct the ``/customers`` router with injected service providers.
+
+    ``service_provider`` is a zero-arg callable returning a
+    :class:`CustomerService` (per-request). Letting the factory hold a
+    closure rather than the service directly mirrors the pattern used by
+    ``create_admin_router`` and keeps the service per-request when wiring a
+    real DB session later.
+    """
+    router = APIRouter()
+
+    @router.post(
+        "",
+        response_model=CustomerRead,
+        status_code=status.HTTP_201_CREATED,
+        dependencies=[Depends(require_customers_write)],
+    )
+    @limiter.limit("60/minute")
+    async def create_customer(
+        request: Request,
+        body: CustomerCreate,
+    ) -> CustomerRead:
+        """Create a customer (write permission required)."""
+        service = service_provider()
+        tenant_id = _tenant_id(request)
+        user_id = _user_id(request)
+        cust = await service.create(
+            tenant_id=tenant_id,
+            user_id=user_id,
+            name=body.name,
+            email=body.email,
+            phone=body.phone,
+            notes=body.notes,
+        )
+        return CustomerRead.model_validate(cust)
+
+    @router.get(
+        "",
+        response_model=CustomerList,
+        dependencies=[Depends(require_customers_read)],
+    )
+    async def list_customers(
+        request: Request,
+        search: Annotated[str | None, Query(max_length=255)] = None,
+        archived: Annotated[bool, Query()] = False,
+        limit: Annotated[int, Query(ge=1, le=200)] = 50,
+        offset: Annotated[int, Query(ge=0)] = 0,
+    ) -> CustomerList:
+        """List customers (paginated, optionally substring-filtered)."""
+        service = service_provider()
+        tenant_id = _tenant_id(request)
+        rows, total = await service.list(
+            tenant_id,
+            search=search,
+            archived=archived,
+            limit=limit,
+            offset=offset,
+        )
+        items = [
+            CustomerSummary(
+                id=r.id,
+                name=r.name,
+                archived=r.archived,
+                location_count=0,
+                primary_city=None,
+            )
+            for r in rows
+        ]
+        return CustomerList(items=items, total=total, limit=limit, offset=offset)
+
+    @router.get(
+        "/{customer_id}",
+        response_model=CustomerRead,
+        dependencies=[Depends(require_customers_read)],
+    )
+    async def get_customer(
+        request: Request,
+        customer_id: Annotated[UUID, Path()],
+    ) -> CustomerRead:
+        """Get a customer, including embedded locations."""
+        service = service_provider()
+        tenant_id = _tenant_id(request)
+        try:
+            cust = await service.get(tenant_id, customer_id)
+        except CustomerNotFoundError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+            ) from exc
+
+        locations: list[LocationRead] = []
+        if location_service_provider is not None:
+            loc_service = location_service_provider()
+            locs = await loc_service.list_for_customer(tenant_id, customer_id)
+            locations = [LocationRead.model_validate(loc) for loc in locs]
+
+        read = CustomerRead.model_validate(cust)
+        # Pydantic v2: model_copy avoids losing extra fields when ``locations``
+        # was originally an empty list from the ORM attribute.
+        return read.model_copy(update={"locations": locations})
+
+    @router.patch(
+        "/{customer_id}",
+        response_model=CustomerRead,
+        dependencies=[Depends(require_customers_write)],
+    )
+    async def update_customer(
+        request: Request,
+        customer_id: Annotated[UUID, Path()],
+        body: CustomerUpdate,
+    ) -> CustomerRead:
+        """Apply a partial update."""
+        service = service_provider()
+        tenant_id = _tenant_id(request)
+        user_id = _user_id(request)
+        patch: dict[str, Any] = body.model_dump(exclude_unset=True)
+        try:
+            cust = await service.update(tenant_id, user_id, customer_id, patch)
+        except CustomerNotFoundError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+            ) from exc
+        return CustomerRead.model_validate(cust)
+
+    @router.post(
+        "/{customer_id}/archive",
+        response_model=CustomerRead,
+        dependencies=[Depends(require_customer_admin)],
+    )
+    async def archive_customer(
+        request: Request,
+        customer_id: Annotated[UUID, Path()],
+    ) -> CustomerRead:
+        """Soft-delete a customer (admin only)."""
+        service = service_provider()
+        tenant_id = _tenant_id(request)
+        user_id = _user_id(request)
+        try:
+            cust = await service.archive(tenant_id, user_id, customer_id)
+        except CustomerNotFoundError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+            ) from exc
+        return CustomerRead.model_validate(cust)
+
+    @router.post(
+        "/{customer_id}/restore",
+        response_model=CustomerRead,
+        dependencies=[Depends(require_customer_admin)],
+    )
+    async def restore_customer(
+        request: Request,
+        customer_id: Annotated[UUID, Path()],
+    ) -> CustomerRead:
+        """Clear the archived flag (admin only)."""
+        service = service_provider()
+        tenant_id = _tenant_id(request)
+        user_id = _user_id(request)
+        try:
+            cust = await service.restore(tenant_id, user_id, customer_id)
+        except CustomerNotFoundError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+            ) from exc
+        return CustomerRead.model_validate(cust)
+
+    return router

--- a/src/office_hero/api/routes/customers.py
+++ b/src/office_hero/api/routes/customers.py
@@ -26,7 +26,6 @@ from office_hero.api.schemas.location import LocationRead
 from office_hero.core.exceptions import CustomerNotFoundError
 from office_hero.core.logging import get_logger
 from office_hero.core.roles import Role
-from office_hero.services.customer_service import CustomerService
 
 log = get_logger(__name__)
 
@@ -34,9 +33,7 @@ log = get_logger(__name__)
 # them via ``app.dependency_overrides``.
 require_customers_read = require_permission("customers:read")
 require_customers_write = require_permission("customers:write")
-require_customer_admin = require_role(
-    [Role.TenantAdmin, Role.Operator, Role.OperatorStaff]
-)
+require_customer_admin = require_role([Role.TenantAdmin, Role.Operator, Role.OperatorStaff])
 
 
 def _tenant_id(request: Request) -> UUID:
@@ -144,9 +141,7 @@ def create_customer_router(
         try:
             cust = await service.get(tenant_id, customer_id)
         except CustomerNotFoundError as exc:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
-            ) from exc
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
 
         locations: list[LocationRead] = []
         if location_service_provider is not None:
@@ -177,9 +172,7 @@ def create_customer_router(
         try:
             cust = await service.update(tenant_id, user_id, customer_id, patch)
         except CustomerNotFoundError as exc:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
-            ) from exc
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
         return CustomerRead.model_validate(cust)
 
     @router.post(
@@ -198,9 +191,7 @@ def create_customer_router(
         try:
             cust = await service.archive(tenant_id, user_id, customer_id)
         except CustomerNotFoundError as exc:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
-            ) from exc
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
         return CustomerRead.model_validate(cust)
 
     @router.post(
@@ -219,9 +210,7 @@ def create_customer_router(
         try:
             cust = await service.restore(tenant_id, user_id, customer_id)
         except CustomerNotFoundError as exc:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
-            ) from exc
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
         return CustomerRead.model_validate(cust)
 
     return router

--- a/src/office_hero/api/routes/customers.py
+++ b/src/office_hero/api/routes/customers.py
@@ -23,7 +23,7 @@ from office_hero.api.schemas.customer import (
     CustomerUpdate,
 )
 from office_hero.api.schemas.location import LocationRead
-from office_hero.core.exceptions import CustomerNotFoundError
+from office_hero.core.exceptions import CustomerNotFoundError, DuplicateEmailError
 from office_hero.core.logging import get_logger
 from office_hero.core.roles import Role
 
@@ -82,14 +82,20 @@ def create_customer_router(
         service = service_provider()
         tenant_id = _tenant_id(request)
         user_id = _user_id(request)
-        cust = await service.create(
-            tenant_id=tenant_id,
-            user_id=user_id,
-            name=body.name,
-            email=body.email,
-            phone=body.phone,
-            notes=body.notes,
-        )
+        try:
+            cust = await service.create(
+                tenant_id=tenant_id,
+                user_id=user_id,
+                name=body.name,
+                email=body.email,
+                phone=body.phone,
+                notes=body.notes,
+            )
+        except DuplicateEmailError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=exc.message,
+            ) from exc
         return CustomerRead.model_validate(cust)
 
     @router.get(
@@ -107,7 +113,7 @@ def create_customer_router(
         """List customers (paginated, optionally substring-filtered)."""
         service = service_provider()
         tenant_id = _tenant_id(request)
-        rows, total = await service.list(
+        rows, total = await service.list_summaries(
             tenant_id,
             search=search,
             archived=archived,
@@ -119,10 +125,10 @@ def create_customer_router(
                 id=r.id,
                 name=r.name,
                 archived=r.archived,
-                location_count=0,
-                primary_city=None,
+                location_count=location_count,
+                primary_city=primary_city,
             )
-            for r in rows
+            for r, location_count, primary_city in rows
         ]
         return CustomerList(items=items, total=total, limit=limit, offset=offset)
 

--- a/src/office_hero/api/routes/locations.py
+++ b/src/office_hero/api/routes/locations.py
@@ -28,12 +28,8 @@ log = get_logger(__name__)
 
 require_customers_read = require_permission("customers:read")
 require_customers_write = require_permission("customers:write")
-require_dispatch_or_admin = require_role(
-    [Role.Dispatcher, Role.TenantAdmin, Role.Operator]
-)
-require_archive_role = require_role(
-    [Role.TenantAdmin, Role.Operator, Role.OperatorStaff]
-)
+require_dispatch_or_admin = require_role([Role.Dispatcher, Role.TenantAdmin, Role.Operator])
+require_archive_role = require_role([Role.TenantAdmin, Role.Operator, Role.OperatorStaff])
 
 
 def _tenant_id(request: Request) -> UUID:
@@ -93,9 +89,7 @@ def create_location_router(*, service_provider) -> APIRouter:
         except CustomerNotFoundError as exc:
             # Surface as 404 so cross-tenant attempts get the standard
             # silent-isolation behaviour.
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
-            ) from exc
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
 
         return LocationRead.model_validate(loc)
 
@@ -114,9 +108,7 @@ def create_location_router(*, service_provider) -> APIRouter:
         try:
             locs = await service.list_for_customer(tenant_id, customer_id)
         except CustomerNotFoundError as exc:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
-            ) from exc
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
         return [LocationRead.model_validate(loc) for loc in locs]
 
     @router.get(
@@ -134,9 +126,7 @@ def create_location_router(*, service_provider) -> APIRouter:
         try:
             loc = await service.get(tenant_id, location_id)
         except LocationNotFoundError as exc:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
-            ) from exc
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
         return LocationRead.model_validate(loc)
 
     @router.patch(
@@ -157,13 +147,9 @@ def create_location_router(*, service_provider) -> APIRouter:
         data: dict[str, Any] = body.model_dump(exclude_unset=True)
         regeocode = data.pop("regeocode", "auto")
         try:
-            loc = await service.update(
-                tenant_id, user_id, location_id, data, regeocode=regeocode
-            )
+            loc = await service.update(tenant_id, user_id, location_id, data, regeocode=regeocode)
         except LocationNotFoundError as exc:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
-            ) from exc
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
         return LocationRead.model_validate(loc)
 
     @router.post(
@@ -185,9 +171,7 @@ def create_location_router(*, service_provider) -> APIRouter:
                 tenant_id, user_id, location_id, body.lat, body.lng
             )
         except LocationNotFoundError as exc:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
-            ) from exc
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
         return LocationRead.model_validate(loc)
 
     @router.post(
@@ -207,9 +191,7 @@ def create_location_router(*, service_provider) -> APIRouter:
         try:
             loc = await service.regeocode(tenant_id, user_id, location_id)
         except LocationNotFoundError as exc:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
-            ) from exc
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
         return LocationRead.model_validate(loc)
 
     @router.post(
@@ -228,9 +210,7 @@ def create_location_router(*, service_provider) -> APIRouter:
         try:
             loc = await service.archive(tenant_id, user_id, location_id)
         except LocationNotFoundError as exc:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
-            ) from exc
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
         return LocationRead.model_validate(loc)
 
     return router

--- a/src/office_hero/api/routes/locations.py
+++ b/src/office_hero/api/routes/locations.py
@@ -1,0 +1,236 @@
+"""Location API routes — CRUD + geocoding controls under a Customer parent."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Request, status
+
+from office_hero.api.deps import require_permission, require_role
+from office_hero.api.limiter import limiter
+from office_hero.api.schemas.location import (
+    LocationCoordinatesSet,
+    LocationCreate,
+    LocationRead,
+    LocationUpdate,
+)
+from office_hero.core.exceptions import (
+    CustomerNotFoundError,
+    LocationNotFoundError,
+)
+from office_hero.core.logging import get_logger
+from office_hero.core.roles import Role
+from office_hero.services.location_service import LocationService
+
+log = get_logger(__name__)
+
+
+require_customers_read = require_permission("customers:read")
+require_customers_write = require_permission("customers:write")
+require_dispatch_or_admin = require_role(
+    [Role.Dispatcher, Role.TenantAdmin, Role.Operator]
+)
+require_archive_role = require_role(
+    [Role.TenantAdmin, Role.Operator, Role.OperatorStaff]
+)
+
+
+def _tenant_id(request: Request) -> UUID:
+    """Extract tenant_id from request.state; raise 401 if missing."""
+    raw = getattr(request.state, "tenant_id", None)
+    if not raw:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+    return raw if isinstance(raw, UUID) else UUID(str(raw))
+
+
+def _user_id(request: Request) -> UUID:
+    """Extract user_id from request.state for audit attribution."""
+    raw = getattr(request.state, "user_id", None)
+    if not raw:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+    return raw if isinstance(raw, UUID) else UUID(str(raw))
+
+
+def create_location_router(*, service_provider) -> APIRouter:
+    """Construct the locations router. See ``create_customer_router``."""
+    router = APIRouter()
+
+    @router.post(
+        "/customers/{customer_id}/locations",
+        response_model=LocationRead,
+        status_code=status.HTTP_201_CREATED,
+        dependencies=[Depends(require_customers_write)],
+    )
+    @limiter.limit("60/minute")
+    async def create_location(
+        request: Request,
+        customer_id: Annotated[UUID, Path()],
+        body: LocationCreate,
+    ) -> LocationRead:
+        """Create a location under ``customer_id`` and (optionally) geocode it."""
+        service: LocationService = service_provider()
+        tenant_id = _tenant_id(request)
+        user_id = _user_id(request)
+
+        address_fields = {
+            "street": body.street,
+            "street2": body.street2,
+            "city": body.city,
+            "state": body.state,
+            "postal_code": body.postal_code,
+            "country": body.country,
+        }
+        try:
+            loc = await service.create(
+                tenant_id=tenant_id,
+                user_id=user_id,
+                customer_id=customer_id,
+                address_fields=address_fields,
+                label=body.label,
+                geocode=body.geocode,
+            )
+        except CustomerNotFoundError as exc:
+            # Surface as 404 so cross-tenant attempts get the standard
+            # silent-isolation behaviour.
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+            ) from exc
+
+        return LocationRead.model_validate(loc)
+
+    @router.get(
+        "/customers/{customer_id}/locations",
+        response_model=list[LocationRead],
+        dependencies=[Depends(require_customers_read)],
+    )
+    async def list_locations(
+        request: Request,
+        customer_id: Annotated[UUID, Path()],
+    ) -> list[LocationRead]:
+        """List a customer's locations."""
+        service: LocationService = service_provider()
+        tenant_id = _tenant_id(request)
+        try:
+            locs = await service.list_for_customer(tenant_id, customer_id)
+        except CustomerNotFoundError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+            ) from exc
+        return [LocationRead.model_validate(loc) for loc in locs]
+
+    @router.get(
+        "/locations/{location_id}",
+        response_model=LocationRead,
+        dependencies=[Depends(require_customers_read)],
+    )
+    async def get_location(
+        request: Request,
+        location_id: Annotated[UUID, Path()],
+    ) -> LocationRead:
+        """Get a single location by id (tenant-scoped)."""
+        service: LocationService = service_provider()
+        tenant_id = _tenant_id(request)
+        try:
+            loc = await service.get(tenant_id, location_id)
+        except LocationNotFoundError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+            ) from exc
+        return LocationRead.model_validate(loc)
+
+    @router.patch(
+        "/locations/{location_id}",
+        response_model=LocationRead,
+        dependencies=[Depends(require_customers_write)],
+    )
+    async def update_location(
+        request: Request,
+        location_id: Annotated[UUID, Path()],
+        body: LocationUpdate,
+    ) -> LocationRead:
+        """Update a location; may auto re-geocode on address change."""
+        service: LocationService = service_provider()
+        tenant_id = _tenant_id(request)
+        user_id = _user_id(request)
+
+        data: dict[str, Any] = body.model_dump(exclude_unset=True)
+        regeocode = data.pop("regeocode", "auto")
+        try:
+            loc = await service.update(
+                tenant_id, user_id, location_id, data, regeocode=regeocode
+            )
+        except LocationNotFoundError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+            ) from exc
+        return LocationRead.model_validate(loc)
+
+    @router.post(
+        "/locations/{location_id}/coordinates",
+        response_model=LocationRead,
+        dependencies=[Depends(require_dispatch_or_admin)],
+    )
+    async def set_coordinates(
+        request: Request,
+        location_id: Annotated[UUID, Path()],
+        body: LocationCoordinatesSet,
+    ) -> LocationRead:
+        """Manual coordinate override (Dispatcher/Admin/Operator only)."""
+        service: LocationService = service_provider()
+        tenant_id = _tenant_id(request)
+        user_id = _user_id(request)
+        try:
+            loc = await service.manual_set_coordinates(
+                tenant_id, user_id, location_id, body.lat, body.lng
+            )
+        except LocationNotFoundError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+            ) from exc
+        return LocationRead.model_validate(loc)
+
+    @router.post(
+        "/locations/{location_id}/regeocode",
+        response_model=LocationRead,
+        dependencies=[Depends(require_dispatch_or_admin)],
+    )
+    @limiter.limit("5/minute")
+    async def regeocode_location(
+        request: Request,
+        location_id: Annotated[UUID, Path()],
+    ) -> LocationRead:
+        """Force a re-geocode (rate-limited to protect Nominatim quota)."""
+        service: LocationService = service_provider()
+        tenant_id = _tenant_id(request)
+        user_id = _user_id(request)
+        try:
+            loc = await service.regeocode(tenant_id, user_id, location_id)
+        except LocationNotFoundError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+            ) from exc
+        return LocationRead.model_validate(loc)
+
+    @router.post(
+        "/locations/{location_id}/archive",
+        response_model=LocationRead,
+        dependencies=[Depends(require_archive_role)],
+    )
+    async def archive_location(
+        request: Request,
+        location_id: Annotated[UUID, Path()],
+    ) -> LocationRead:
+        """Soft-delete a location (admin only)."""
+        service: LocationService = service_provider()
+        tenant_id = _tenant_id(request)
+        user_id = _user_id(request)
+        try:
+            loc = await service.archive(tenant_id, user_id, location_id)
+        except LocationNotFoundError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+            ) from exc
+        return LocationRead.model_validate(loc)
+
+    return router

--- a/src/office_hero/api/schemas/__init__.py
+++ b/src/office_hero/api/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Pydantic request/response schemas grouped by resource."""

--- a/src/office_hero/api/schemas/customer.py
+++ b/src/office_hero/api/schemas/customer.py
@@ -6,9 +6,16 @@ from datetime import datetime
 from typing import Self
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from office_hero.api.schemas.location import LocationRead
+
+# Light email validation regex applied as a Pydantic ``pattern`` on the
+# ``email`` field. We avoid Pydantic's ``EmailStr`` (which requires the
+# optional ``email-validator`` extra) to keep dependency surface small —
+# strict RFC validation lives on the back-end normalisation path when one
+# is wired in a follow-up slice.
+_EMAIL_PATTERN = r"^[^@\s]+@[^@\s]+\.[^@\s]+$"
 
 
 class CustomerCreate(BaseModel):
@@ -17,7 +24,7 @@ class CustomerCreate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: str = Field(min_length=1, max_length=255)
-    email: EmailStr | None = None
+    email: str | None = Field(default=None, max_length=255, pattern=_EMAIL_PATTERN)
     phone: str | None = Field(default=None, max_length=50)
     notes: str | None = None
 
@@ -28,7 +35,7 @@ class CustomerUpdate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: str | None = Field(default=None, min_length=1, max_length=255)
-    email: EmailStr | None = None
+    email: str | None = Field(default=None, max_length=255, pattern=_EMAIL_PATTERN)
     phone: str | None = Field(default=None, max_length=50)
     notes: str | None = None
 

--- a/src/office_hero/api/schemas/customer.py
+++ b/src/office_hero/api/schemas/customer.py
@@ -1,0 +1,81 @@
+"""Pydantic v2 request/response schemas for the Customer resource (HLD A03)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Self
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, model_validator
+
+from office_hero.api.schemas.location import LocationRead
+
+
+class CustomerCreate(BaseModel):
+    """Request body for ``POST /customers``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1, max_length=255)
+    email: EmailStr | None = None
+    phone: str | None = Field(default=None, max_length=50)
+    notes: str | None = None
+
+
+class CustomerUpdate(BaseModel):
+    """Request body for ``PATCH /customers/{id}`` (all optional)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    email: EmailStr | None = None
+    phone: str | None = Field(default=None, max_length=50)
+    notes: str | None = None
+
+    @model_validator(mode="after")
+    def _at_least_one(self) -> Self:
+        """Reject empty patches — there has to be something to update."""
+        if not self.model_dump(exclude_unset=True):
+            raise ValueError("PATCH must update at least one field")
+        return self
+
+
+class CustomerSummary(BaseModel):
+    """Cheap projection used in list views."""
+
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
+
+    id: UUID
+    name: str
+    archived: bool
+    location_count: int = 0
+    primary_city: str | None = None
+
+
+class CustomerRead(BaseModel):
+    """Full read view (optionally with embedded locations)."""
+
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
+
+    id: UUID
+    tenant_id: UUID
+    name: str
+    email: str | None = None
+    phone: str | None = None
+    notes: str | None = None
+    archived: bool
+    external_id: str | None = None
+    created_at: datetime
+    updated_at: datetime
+    locations: list[LocationRead] = Field(default_factory=list)
+
+
+class CustomerList(BaseModel):
+    """Paginated list response."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[CustomerSummary]
+    total: int
+    limit: int
+    offset: int

--- a/src/office_hero/api/schemas/location.py
+++ b/src/office_hero/api/schemas/location.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Literal, Self
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, computed_field, model_validator
 
 
 class LocationCreate(BaseModel):
@@ -74,9 +74,15 @@ class LocationRead(BaseModel):
     country: str
     lat: float | None = None
     lng: float | None = None
-    geocode_source: str | None = None
-    geocode_status: str
+    geocode_source: Literal["nominatim", "ors", "manual", "stub"] | None = None
+    geocode_status: Literal["pending", "ok", "failed", "manual"]
     geocoded_at: datetime | None = None
     archived: bool
     created_at: datetime
     updated_at: datetime
+
+    @computed_field
+    @property
+    def formatted_address(self) -> str:
+        parts = [self.street, self.city, self.state, self.postal_code]
+        return ", ".join(p for p in parts if p)

--- a/src/office_hero/api/schemas/location.py
+++ b/src/office_hero/api/schemas/location.py
@@ -1,0 +1,82 @@
+"""Pydantic v2 schemas for the Location resource (HLD A03)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, Self
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class LocationCreate(BaseModel):
+    """Request body for ``POST /customers/{customer_id}/locations``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    label: str | None = Field(default=None, max_length=255)
+    street: str = Field(min_length=1, max_length=255)
+    street2: str | None = Field(default=None, max_length=255)
+    city: str = Field(min_length=1, max_length=120)
+    state: str = Field(min_length=1, max_length=60)
+    postal_code: str = Field(min_length=1, max_length=20)
+    country: str = Field(default="US", min_length=2, max_length=2)
+    geocode: bool = True
+
+
+class LocationUpdate(BaseModel):
+    """Request body for ``PATCH /locations/{id}``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    label: str | None = Field(default=None, max_length=255)
+    street: str | None = Field(default=None, max_length=255)
+    street2: str | None = Field(default=None, max_length=255)
+    city: str | None = Field(default=None, max_length=120)
+    state: str | None = Field(default=None, max_length=60)
+    postal_code: str | None = Field(default=None, max_length=20)
+    country: str | None = Field(default=None, min_length=2, max_length=2)
+    regeocode: bool | Literal["auto"] = "auto"
+
+    @model_validator(mode="after")
+    def _at_least_one_field(self) -> Self:
+        """Patch must touch something beyond ``regeocode``."""
+        data = self.model_dump(exclude_unset=True)
+        data.pop("regeocode", None)
+        if not data:
+            raise ValueError("PATCH must update at least one field")
+        return self
+
+
+class LocationCoordinatesSet(BaseModel):
+    """Request body for the manual coordinates override endpoint."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    lat: float = Field(ge=-90.0, le=90.0)
+    lng: float = Field(ge=-180.0, le=180.0)
+
+
+class LocationRead(BaseModel):
+    """Full read view of a Location."""
+
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
+
+    id: UUID
+    tenant_id: UUID
+    customer_id: UUID
+    label: str | None = None
+    street: str
+    street2: str | None = None
+    city: str
+    state: str
+    postal_code: str
+    country: str
+    lat: float | None = None
+    lng: float | None = None
+    geocode_source: str | None = None
+    geocode_status: str
+    geocoded_at: datetime | None = None
+    archived: bool
+    created_at: datetime
+    updated_at: datetime

--- a/src/office_hero/api/state.py
+++ b/src/office_hero/api/state.py
@@ -1,14 +1,24 @@
-"""Global app state for engine and auth service."""
+"""Global app state for engine, auth service, and slice 9 services/adapters."""
 
 from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from office_hero.services.auth_service import AuthService
 
+if TYPE_CHECKING:
+    from office_hero.adapters.geocoding.protocol import GeocodingAdapter
+    from office_hero.services.customer_service import CustomerService
+    from office_hero.services.location_service import LocationService
+
 # Global variables for app lifecycle
 _engine: AsyncEngine | None = None
 _auth_service: AuthService | None = None
+_customer_service: CustomerService | None = None
+_location_service: LocationService | None = None
+_geocoding_adapter: GeocodingAdapter | None = None
 
 
 def get_engine() -> AsyncEngine:
@@ -39,3 +49,51 @@ def set_auth_service(auth_service: AuthService) -> None:
     """Set the global auth service instance."""
     global _auth_service
     _auth_service = auth_service
+
+
+# --- Slice 9: Customer / Location services and the geocoding adapter ---
+
+
+def set_customer_service(service: CustomerService) -> None:
+    """Register the customer service used by the route factory."""
+    global _customer_service
+    _customer_service = service
+
+
+def get_customer_service() -> CustomerService:
+    """Retrieve the registered customer service."""
+    if _customer_service is None:
+        raise RuntimeError(
+            "CustomerService not initialized. " "Ensure app has been created with create_app()."
+        )
+    return _customer_service
+
+
+def set_location_service(service: LocationService) -> None:
+    """Register the location service used by the route factory."""
+    global _location_service
+    _location_service = service
+
+
+def get_location_service() -> LocationService:
+    """Retrieve the registered location service."""
+    if _location_service is None:
+        raise RuntimeError(
+            "LocationService not initialized. " "Ensure app has been created with create_app()."
+        )
+    return _location_service
+
+
+def set_geocoding_adapter(adapter: GeocodingAdapter) -> None:
+    """Register the active geocoding adapter."""
+    global _geocoding_adapter
+    _geocoding_adapter = adapter
+
+
+def get_geocoding_adapter() -> GeocodingAdapter:
+    """Retrieve the active geocoding adapter."""
+    if _geocoding_adapter is None:
+        raise RuntimeError(
+            "GeocodingAdapter not initialized. " "Ensure app has been created with create_app()."
+        )
+    return _geocoding_adapter

--- a/src/office_hero/core/config.py
+++ b/src/office_hero/core/config.py
@@ -28,6 +28,19 @@ class Settings(BaseSettings):
     access_token_ttl_minutes: int = 15
     refresh_token_ttl_days: int = 7
 
+    # --- Slice 9: Geocoding (Customer & Location) ---
+    # The geocoder is pluggable; default to Nominatim (OSM free tier) per the
+    # slice design doc. Switch to ORS in a future slice when an API key is
+    # provisioned. Use ``"stub"`` in tests to keep CI off the live network.
+    nominatim_base_url: str = "https://nominatim.openstreetmap.org"
+    nominatim_user_agent: str = "office-hero/0.1 (contact@office-hero.example)"
+    geocoding_adapter: str = "nominatim"
+    geocoding_timeout_s: float = 5.0
+    geocoding_allowlist: list[str] = [
+        "nominatim.openstreetmap.org",
+        "api.openrouteservice.org",
+    ]
+
 
 def get_settings() -> Settings:
     """Lazily load settings once."""

--- a/src/office_hero/core/exceptions.py
+++ b/src/office_hero/core/exceptions.py
@@ -55,3 +55,16 @@ class LocationNotFoundError(Exception):
         self.message = message
         self.request_id = request_id
         super().__init__(message)
+
+
+class DuplicateEmailError(Exception):
+    """Raised when a customer email already exists in the same tenant (active)."""
+
+    def __init__(
+        self,
+        message: str = "A customer with this email already exists in this tenant",
+        request_id: str | None = None,
+    ):
+        self.message = message
+        self.request_id = request_id
+        super().__init__(message)

--- a/src/office_hero/core/exceptions.py
+++ b/src/office_hero/core/exceptions.py
@@ -28,3 +28,30 @@ class TenantError(Exception):
         self.message = message
         self.request_id = request_id
         super().__init__(message)
+
+
+class GeocodingError(Exception):
+    """Raised when a geocoding adapter fails (network, timeout, parse, allowlist)."""
+
+    def __init__(self, message: str = "Geocoding failed", request_id: str | None = None):
+        self.message = message
+        self.request_id = request_id
+        super().__init__(message)
+
+
+class CustomerNotFoundError(Exception):
+    """Raised when a customer cannot be located in the caller's tenant scope."""
+
+    def __init__(self, message: str = "Customer not found", request_id: str | None = None):
+        self.message = message
+        self.request_id = request_id
+        super().__init__(message)
+
+
+class LocationNotFoundError(Exception):
+    """Raised when a location cannot be located in the caller's tenant scope."""
+
+    def __init__(self, message: str = "Location not found", request_id: str | None = None):
+        self.message = message
+        self.request_id = request_id
+        super().__init__(message)

--- a/src/office_hero/models/__init__.py
+++ b/src/office_hero/models/__init__.py
@@ -12,6 +12,8 @@ class Base(DeclarativeBase):
 
 
 # Import all models so they register with Base.metadata
+from office_hero.models.customer import Customer  # noqa: F401, E402
+from office_hero.models.location import Location  # noqa: F401, E402
 from office_hero.models.tenant import Tenant  # noqa: F401, E402
 from office_hero.models.token import RefreshToken  # noqa: F401, E402
 from office_hero.models.user import User  # noqa: F401, E402

--- a/src/office_hero/models/customer.py
+++ b/src/office_hero/models/customer.py
@@ -1,0 +1,58 @@
+"""Customer ORM model — top-level FSM aggregate (1:N Locations)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from office_hero.models import Base
+
+if TYPE_CHECKING:
+    from office_hero.models.location import Location
+
+
+class Customer(Base):
+    """Tenant-scoped customer (Field Service Management) aggregate.
+
+    Tenant isolation is enforced by RLS (see ADR 053); the application also
+    re-checks tenant ownership defensively on every read/write (defence in
+    depth).
+    """
+
+    __tablename__ = "customers"
+
+    id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4)
+    tenant_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    phone: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    archived: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    # Optional back-office system identifier (ADR 056). Indexed by the
+    # back-office adapter to correlate sync events with this row.
+    external_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    locations: Mapped[list[Location]] = relationship(
+        "Location",
+        back_populates="customer",
+        cascade="all, delete-orphan",
+    )
+
+    def __repr__(self) -> str:
+        return f"<Customer(id={self.id}, name={self.name!r}, tenant_id={self.tenant_id})>"

--- a/src/office_hero/models/location.py
+++ b/src/office_hero/models/location.py
@@ -1,0 +1,85 @@
+"""Location ORM model — one Customer has many service Locations (1:N)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    Numeric,
+    String,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from office_hero.models import Base
+
+if TYPE_CHECKING:
+    from office_hero.models.customer import Customer
+
+
+class Location(Base):
+    """A physical service site belonging to a :class:`Customer`.
+
+    Coordinates (``lat``/``lng``) are populated asynchronously by the
+    geocoding adapter; ``geocode_status`` tracks the lifecycle so a worker
+    can pick up ``"pending"`` rows in bulk.
+    """
+
+    __tablename__ = "locations"
+
+    id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4)
+    tenant_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False
+    )
+    customer_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("customers.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    label: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    street: Mapped[str] = mapped_column(String(255), nullable=False)
+    street2: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    city: Mapped[str] = mapped_column(String(120), nullable=False)
+    state: Mapped[str] = mapped_column(String(60), nullable=False)
+    postal_code: Mapped[str] = mapped_column(String(20), nullable=False)
+    country: Mapped[str] = mapped_column(String(2), nullable=False, default="US")
+    lat: Mapped[Decimal | None] = mapped_column(Numeric(9, 6), nullable=True)
+    lng: Mapped[Decimal | None] = mapped_column(Numeric(9, 6), nullable=True)
+    geocode_source: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    geocode_status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="pending"
+    )
+    geocoded_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    archived: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    customer: Mapped[Customer] = relationship("Customer", back_populates="locations")
+
+    __table_args__ = (
+        Index("idx_location_tenant_customer", "tenant_id", "customer_id"),
+        Index("idx_location_tenant_status", "tenant_id", "geocode_status"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<Location(id={self.id}, customer_id={self.customer_id}, "
+            f"street={self.street!r}, status={self.geocode_status})>"
+        )

--- a/src/office_hero/models/location.py
+++ b/src/office_hero/models/location.py
@@ -54,12 +54,8 @@ class Location(Base):
     lat: Mapped[Decimal | None] = mapped_column(Numeric(9, 6), nullable=True)
     lng: Mapped[Decimal | None] = mapped_column(Numeric(9, 6), nullable=True)
     geocode_source: Mapped[str | None] = mapped_column(String(50), nullable=True)
-    geocode_status: Mapped[str] = mapped_column(
-        String(20), nullable=False, default="pending"
-    )
-    geocoded_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    geocode_status: Mapped[str] = mapped_column(String(20), nullable=False, default="pending")
+    geocoded_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     archived: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/src/office_hero/repositories/customer_repository.py
+++ b/src/office_hero/repositories/customer_repository.py
@@ -17,8 +17,9 @@ from uuid import UUID, uuid4
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from office_hero.core.exceptions import CustomerNotFoundError
+from office_hero.core.exceptions import CustomerNotFoundError, DuplicateEmailError
 from office_hero.models.customer import Customer
+from office_hero.models.location import Location
 
 
 @runtime_checkable
@@ -47,6 +48,16 @@ class CustomerRepositoryProtocol(Protocol):
         limit: int = 50,
         offset: int = 0,
     ) -> tuple[list[Customer], int]: ...
+
+    async def list_summaries(
+        self,
+        tenant_id: UUID,
+        *,
+        search: str | None = None,
+        archived: bool = False,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[tuple[Customer, int, str | None]], int]: ...
 
     async def update(self, customer_id: UUID, tenant_id: UUID, **patch: Any) -> Customer: ...
 
@@ -120,6 +131,54 @@ class CustomerRepository:
         rows = list((await self.session.execute(rows_stmt)).scalars().all())
         return rows, total
 
+    async def list_summaries(
+        self,
+        tenant_id: UUID,
+        *,
+        search: str | None = None,
+        archived: bool = False,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[tuple[Customer, int, str | None]], int]:
+        """Return ``(rows, total)`` where each row is ``(customer, location_count, primary_city)``.
+
+        ``location_count`` is the number of non-archived locations; ``primary_city``
+        is the city of the lowest-id non-archived location (None when there are none).
+        """
+        where_clauses = [Customer.tenant_id == tenant_id, Customer.archived.is_(archived)]
+        if search:
+            pattern = f"%{search}%"
+            where_clauses.append(or_(Customer.name.ilike(pattern), Customer.email.ilike(pattern)))
+
+        location_count_subq = (
+            select(func.count(Location.id))
+            .where(Location.customer_id == Customer.id)
+            .where(Location.archived.is_(False))
+            .scalar_subquery()
+        )
+        primary_city_subq = (
+            select(Location.city)
+            .where(Location.customer_id == Customer.id)
+            .where(Location.archived.is_(False))
+            .order_by(Location.id)
+            .limit(1)
+            .scalar_subquery()
+        )
+
+        count_stmt = select(func.count(Customer.id)).where(*where_clauses)
+        total = int((await self.session.execute(count_stmt)).scalar_one())
+
+        rows_stmt = (
+            select(Customer, location_count_subq.label("location_count"), primary_city_subq.label("primary_city"))
+            .where(*where_clauses)
+            .order_by(Customer.created_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        result = (await self.session.execute(rows_stmt)).all()
+        rows = [(row[0], row[1] or 0, row[2]) for row in result]
+        return rows, total
+
     async def update(self, customer_id: UUID, tenant_id: UUID, **patch: Any) -> Customer:
         """Apply a partial update; raises :class:`CustomerNotFoundError` if absent."""
         cust = await self.get_by_id(customer_id, tenant_id)
@@ -150,11 +209,14 @@ class InMemoryCustomerRepository:
     cross-tenant behaviour of the service layer.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, loc_repo: Any = None) -> None:
         # Snapshot dict {customer_id -> dict}. We store dicts (not the ORM
         # object) and rebuild Customer instances on each read so callers
         # can mutate freely without corrupting the store.
         self._rows: dict[UUID, dict[str, Any]] = {}
+        # Optional reference to an InMemoryLocationRepository so list_summaries
+        # can compute real location_count and primary_city values.
+        self._loc_repo = loc_repo
 
     def _row_to_customer(self, row: dict[str, Any]) -> Customer:
         cust = Customer(
@@ -181,7 +243,20 @@ class InMemoryCustomerRepository:
         notes: str | None = None,
         external_id: str | None = None,
     ) -> Customer:
-        """Insert and return a freshly minted :class:`Customer`."""
+        """Insert and return a freshly minted :class:`Customer`.
+
+        Raises :class:`DuplicateEmailError` if a non-archived customer with
+        the same ``email`` already exists in ``tenant_id`` (mirrors the partial
+        unique index ``uq_customer_tenant_email_active`` on the real DB).
+        """
+        if email is not None:
+            for row in self._rows.values():
+                if (
+                    row["tenant_id"] == tenant_id
+                    and row.get("email") == email
+                    and not row.get("archived", False)
+                ):
+                    raise DuplicateEmailError()
         cid = uuid4()
         now = datetime.now(UTC)
         self._rows[cid] = {
@@ -231,6 +306,50 @@ class InMemoryCustomerRepository:
         total = len(rows)
         page = rows[offset : offset + limit]
         return [self._row_to_customer(r) for r in page], total
+
+    async def list_summaries(
+        self,
+        tenant_id: UUID,
+        *,
+        search: str | None = None,
+        archived: bool = False,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[tuple[Customer, int, str | None]], int]:
+        """Return ``(rows, total)`` where each row is ``(customer, location_count, primary_city)``."""
+        needle = search.lower() if search else None
+        rows = [
+            r
+            for r in self._rows.values()
+            if r["tenant_id"] == tenant_id and r["archived"] == archived
+        ]
+        if needle is not None:
+            rows = [
+                r
+                for r in rows
+                if needle in (r["name"] or "").lower() or needle in ((r.get("email") or "").lower())
+            ]
+        rows.sort(key=lambda r: r["created_at"], reverse=True)
+        total = len(rows)
+        page = rows[offset : offset + limit]
+
+        result: list[tuple[Customer, int, str | None]] = []
+        for row in page:
+            cust = self._row_to_customer(row)
+            location_count = 0
+            primary_city: str | None = None
+            if self._loc_repo is not None:
+                loc_rows = [
+                    lr
+                    for lr in self._loc_repo._rows.values()
+                    if lr["customer_id"] == cust.id and lr["archived"] is False
+                ]
+                location_count = len(loc_rows)
+                if loc_rows:
+                    loc_rows_sorted = sorted(loc_rows, key=lambda lr: lr["created_at"])
+                    primary_city = loc_rows_sorted[0]["city"]
+            result.append((cust, location_count, primary_city))
+        return result, total
 
     async def update(self, customer_id: UUID, tenant_id: UUID, **patch: Any) -> Customer:
         """Apply a partial update; raises if cross-tenant or absent."""

--- a/src/office_hero/repositories/customer_repository.py
+++ b/src/office_hero/repositories/customer_repository.py
@@ -88,9 +88,7 @@ class CustomerRepository:
 
     async def get_by_id(self, customer_id: UUID, tenant_id: UUID) -> Customer | None:
         """Fetch a customer if it exists in ``tenant_id`` (defence-in-depth)."""
-        stmt = select(Customer).where(
-            Customer.id == customer_id, Customer.tenant_id == tenant_id
-        )
+        stmt = select(Customer).where(Customer.id == customer_id, Customer.tenant_id == tenant_id)
         result = await self.session.execute(stmt)
         return result.scalars().first()
 
@@ -227,8 +225,7 @@ class InMemoryCustomerRepository:
             rows = [
                 r
                 for r in rows
-                if needle in (r["name"] or "").lower()
-                or needle in ((r.get("email") or "").lower())
+                if needle in (r["name"] or "").lower() or needle in ((r.get("email") or "").lower())
             ]
         rows.sort(key=lambda r: r["created_at"], reverse=True)
         total = len(rows)

--- a/src/office_hero/repositories/customer_repository.py
+++ b/src/office_hero/repositories/customer_repository.py
@@ -169,7 +169,11 @@ class CustomerRepository:
         total = int((await self.session.execute(count_stmt)).scalar_one())
 
         rows_stmt = (
-            select(Customer, location_count_subq.label("location_count"), primary_city_subq.label("primary_city"))
+            select(
+                Customer,
+                location_count_subq.label("location_count"),
+                primary_city_subq.label("primary_city"),
+            )
             .where(*where_clauses)
             .order_by(Customer.created_at.desc())
             .limit(limit)

--- a/src/office_hero/repositories/customer_repository.py
+++ b/src/office_hero/repositories/customer_repository.py
@@ -1,0 +1,257 @@
+"""Customer repository — protocol, SQLAlchemy impl, and in-memory mock.
+
+The protocol is what the service layer depends on (ADR 058). The concrete
+SQLAlchemy implementation is the production binding. The in-memory mock is
+used by unit tests so the service layer can be exercised without a database.
+All implementations enforce tenant scoping defensively (ADR 053
+defence-in-depth on top of RLS).
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import UTC, datetime
+from typing import Any, Protocol, runtime_checkable
+from uuid import UUID, uuid4
+
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from office_hero.core.exceptions import CustomerNotFoundError
+from office_hero.models.customer import Customer
+
+
+@runtime_checkable
+class CustomerRepositoryProtocol(Protocol):
+    """Repository contract for :class:`Customer` persistence."""
+
+    async def create(
+        self,
+        tenant_id: UUID,
+        *,
+        name: str,
+        email: str | None = None,
+        phone: str | None = None,
+        notes: str | None = None,
+        external_id: str | None = None,
+    ) -> Customer: ...
+
+    async def get_by_id(self, customer_id: UUID, tenant_id: UUID) -> Customer | None: ...
+
+    async def list(
+        self,
+        tenant_id: UUID,
+        *,
+        search: str | None = None,
+        archived: bool = False,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[Customer], int]: ...
+
+    async def update(self, customer_id: UUID, tenant_id: UUID, **patch: Any) -> Customer: ...
+
+    async def archive(self, customer_id: UUID, tenant_id: UUID) -> Customer: ...
+
+    async def restore(self, customer_id: UUID, tenant_id: UUID) -> Customer: ...
+
+
+class CustomerRepository:
+    """SQLAlchemy-backed concrete :class:`Customer` repository (ADR 058)."""
+
+    def __init__(self, session: AsyncSession):
+        """Bind to an async SQLAlchemy session."""
+        self.session = session
+
+    async def create(
+        self,
+        tenant_id: UUID,
+        *,
+        name: str,
+        email: str | None = None,
+        phone: str | None = None,
+        notes: str | None = None,
+        external_id: str | None = None,
+    ) -> Customer:
+        """Insert and flush a new :class:`Customer`."""
+        cust = Customer(
+            tenant_id=tenant_id,
+            name=name,
+            email=email,
+            phone=phone,
+            notes=notes,
+            external_id=external_id,
+            archived=False,
+        )
+        self.session.add(cust)
+        await self.session.flush()
+        return cust
+
+    async def get_by_id(self, customer_id: UUID, tenant_id: UUID) -> Customer | None:
+        """Fetch a customer if it exists in ``tenant_id`` (defence-in-depth)."""
+        stmt = select(Customer).where(
+            Customer.id == customer_id, Customer.tenant_id == tenant_id
+        )
+        result = await self.session.execute(stmt)
+        return result.scalars().first()
+
+    async def list(
+        self,
+        tenant_id: UUID,
+        *,
+        search: str | None = None,
+        archived: bool = False,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[Customer], int]:
+        """Return ``(rows, total)`` for a tenant, optionally substring-filtered."""
+        where_clauses = [Customer.tenant_id == tenant_id, Customer.archived.is_(archived)]
+        if search:
+            pattern = f"%{search}%"
+            where_clauses.append(or_(Customer.name.ilike(pattern), Customer.email.ilike(pattern)))
+
+        count_stmt = select(func.count(Customer.id)).where(*where_clauses)
+        total = int((await self.session.execute(count_stmt)).scalar_one())
+
+        rows_stmt = (
+            select(Customer)
+            .where(*where_clauses)
+            .order_by(Customer.created_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        rows = list((await self.session.execute(rows_stmt)).scalars().all())
+        return rows, total
+
+    async def update(self, customer_id: UUID, tenant_id: UUID, **patch: Any) -> Customer:
+        """Apply a partial update; raises :class:`CustomerNotFoundError` if absent."""
+        cust = await self.get_by_id(customer_id, tenant_id)
+        if cust is None:
+            raise CustomerNotFoundError(f"Customer {customer_id} not found")
+        for key, value in patch.items():
+            if value is None and key in {"name"}:
+                # Don't allow setting required columns to NULL.
+                continue
+            setattr(cust, key, value)
+        await self.session.flush()
+        return cust
+
+    async def archive(self, customer_id: UUID, tenant_id: UUID) -> Customer:
+        """Mark a customer archived (soft delete)."""
+        return await self.update(customer_id, tenant_id, archived=True)
+
+    async def restore(self, customer_id: UUID, tenant_id: UUID) -> Customer:
+        """Clear the archived flag."""
+        return await self.update(customer_id, tenant_id, archived=False)
+
+
+class InMemoryCustomerRepository:
+    """In-memory mock implementing :class:`CustomerRepositoryProtocol`.
+
+    Used by unit tests so the service layer can be exercised without a DB.
+    Tenant scope is honoured on every read/write so tests can assert the
+    cross-tenant behaviour of the service layer.
+    """
+
+    def __init__(self) -> None:
+        # Snapshot dict {customer_id -> dict}. We store dicts (not the ORM
+        # object) and rebuild Customer instances on each read so callers
+        # can mutate freely without corrupting the store.
+        self._rows: dict[UUID, dict[str, Any]] = {}
+
+    def _row_to_customer(self, row: dict[str, Any]) -> Customer:
+        cust = Customer(
+            id=row["id"],
+            tenant_id=row["tenant_id"],
+            name=row["name"],
+            email=row.get("email"),
+            phone=row.get("phone"),
+            notes=row.get("notes"),
+            archived=row.get("archived", False),
+            external_id=row.get("external_id"),
+        )
+        cust.created_at = row["created_at"]
+        cust.updated_at = row["updated_at"]
+        return cust
+
+    async def create(
+        self,
+        tenant_id: UUID,
+        *,
+        name: str,
+        email: str | None = None,
+        phone: str | None = None,
+        notes: str | None = None,
+        external_id: str | None = None,
+    ) -> Customer:
+        """Insert and return a freshly minted :class:`Customer`."""
+        cid = uuid4()
+        now = datetime.now(UTC)
+        self._rows[cid] = {
+            "id": cid,
+            "tenant_id": tenant_id,
+            "name": name,
+            "email": email,
+            "phone": phone,
+            "notes": notes,
+            "external_id": external_id,
+            "archived": False,
+            "created_at": now,
+            "updated_at": now,
+        }
+        return self._row_to_customer(self._rows[cid])
+
+    async def get_by_id(self, customer_id: UUID, tenant_id: UUID) -> Customer | None:
+        """Return the customer if it exists in this tenant's scope."""
+        row = self._rows.get(customer_id)
+        if row is None or row["tenant_id"] != tenant_id:
+            return None
+        return self._row_to_customer(row)
+
+    async def list(
+        self,
+        tenant_id: UUID,
+        *,
+        search: str | None = None,
+        archived: bool = False,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[Customer], int]:
+        """Return ``(rows, total)`` matching the filter."""
+        needle = search.lower() if search else None
+        rows = [
+            r
+            for r in self._rows.values()
+            if r["tenant_id"] == tenant_id and r["archived"] == archived
+        ]
+        if needle is not None:
+            rows = [
+                r
+                for r in rows
+                if needle in (r["name"] or "").lower()
+                or needle in ((r.get("email") or "").lower())
+            ]
+        rows.sort(key=lambda r: r["created_at"], reverse=True)
+        total = len(rows)
+        page = rows[offset : offset + limit]
+        return [self._row_to_customer(r) for r in page], total
+
+    async def update(self, customer_id: UUID, tenant_id: UUID, **patch: Any) -> Customer:
+        """Apply a partial update; raises if cross-tenant or absent."""
+        row = self._rows.get(customer_id)
+        if row is None or row["tenant_id"] != tenant_id:
+            raise CustomerNotFoundError(f"Customer {customer_id} not found")
+        # Avoid mutating the caller's patch dict accidentally.
+        for key, value in deepcopy(patch).items():
+            if key == "name" and value is None:
+                continue
+            row[key] = value
+        row["updated_at"] = datetime.now(UTC)
+        return self._row_to_customer(row)
+
+    async def archive(self, customer_id: UUID, tenant_id: UUID) -> Customer:
+        """Mark the customer archived."""
+        return await self.update(customer_id, tenant_id, archived=True)
+
+    async def restore(self, customer_id: UUID, tenant_id: UUID) -> Customer:
+        """Clear the archived flag."""
+        return await self.update(customer_id, tenant_id, archived=False)

--- a/src/office_hero/repositories/location_repository.py
+++ b/src/office_hero/repositories/location_repository.py
@@ -1,0 +1,342 @@
+"""Location repository — protocol, SQLAlchemy impl, and in-memory mock."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any, Protocol, runtime_checkable
+from uuid import UUID, uuid4
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from office_hero.core.exceptions import LocationNotFoundError
+from office_hero.models.location import Location
+
+
+@runtime_checkable
+class LocationRepositoryProtocol(Protocol):
+    """Repository contract for :class:`Location` persistence."""
+
+    async def create(
+        self,
+        tenant_id: UUID,
+        customer_id: UUID,
+        *,
+        street: str,
+        city: str,
+        state: str,
+        postal_code: str,
+        country: str = "US",
+        street2: str | None = None,
+        label: str | None = None,
+    ) -> Location: ...
+
+    async def get_by_id(self, location_id: UUID, tenant_id: UUID) -> Location | None: ...
+
+    async def list_for_customer(
+        self,
+        customer_id: UUID,
+        tenant_id: UUID,
+        *,
+        archived: bool = False,
+    ) -> list[Location]: ...
+
+    async def list_pending_geocode(
+        self, tenant_id: UUID, limit: int = 50
+    ) -> list[Location]: ...
+
+    async def update(self, location_id: UUID, tenant_id: UUID, **patch: Any) -> Location: ...
+
+    async def set_coordinates(
+        self,
+        location_id: UUID,
+        tenant_id: UUID,
+        lat: float,
+        lng: float,
+        source: str,
+    ) -> Location: ...
+
+    async def mark_geocode_failed(
+        self, location_id: UUID, tenant_id: UUID, error: str
+    ) -> Location: ...
+
+    async def archive(self, location_id: UUID, tenant_id: UUID) -> Location: ...
+
+
+class LocationRepository:
+    """SQLAlchemy-backed concrete :class:`Location` repository."""
+
+    def __init__(self, session: AsyncSession):
+        """Bind to an async SQLAlchemy session."""
+        self.session = session
+
+    async def create(
+        self,
+        tenant_id: UUID,
+        customer_id: UUID,
+        *,
+        street: str,
+        city: str,
+        state: str,
+        postal_code: str,
+        country: str = "US",
+        street2: str | None = None,
+        label: str | None = None,
+    ) -> Location:
+        """Insert a fresh location in ``pending`` geocode status."""
+        loc = Location(
+            tenant_id=tenant_id,
+            customer_id=customer_id,
+            street=street,
+            street2=street2,
+            city=city,
+            state=state,
+            postal_code=postal_code,
+            country=country,
+            label=label,
+            geocode_status="pending",
+            archived=False,
+        )
+        self.session.add(loc)
+        await self.session.flush()
+        return loc
+
+    async def get_by_id(self, location_id: UUID, tenant_id: UUID) -> Location | None:
+        """Tenant-scoped read."""
+        stmt = select(Location).where(
+            Location.id == location_id, Location.tenant_id == tenant_id
+        )
+        return (await self.session.execute(stmt)).scalars().first()
+
+    async def list_for_customer(
+        self,
+        customer_id: UUID,
+        tenant_id: UUID,
+        *,
+        archived: bool = False,
+    ) -> list[Location]:
+        """List a customer's locations within the active tenant."""
+        stmt = (
+            select(Location)
+            .where(
+                Location.tenant_id == tenant_id,
+                Location.customer_id == customer_id,
+                Location.archived.is_(archived),
+            )
+            .order_by(Location.created_at.asc())
+        )
+        return list((await self.session.execute(stmt)).scalars().all())
+
+    async def list_pending_geocode(
+        self, tenant_id: UUID, limit: int = 50
+    ) -> list[Location]:
+        """Worker hook — fetch rows the geocoder still needs to resolve."""
+        stmt = (
+            select(Location)
+            .where(
+                Location.tenant_id == tenant_id,
+                Location.geocode_status == "pending",
+            )
+            .order_by(Location.created_at.asc())
+            .limit(limit)
+        )
+        return list((await self.session.execute(stmt)).scalars().all())
+
+    async def update(self, location_id: UUID, tenant_id: UUID, **patch: Any) -> Location:
+        """Apply a partial update; raises :class:`LocationNotFoundError` if absent."""
+        loc = await self.get_by_id(location_id, tenant_id)
+        if loc is None:
+            raise LocationNotFoundError(f"Location {location_id} not found")
+        for key, value in patch.items():
+            setattr(loc, key, value)
+        await self.session.flush()
+        return loc
+
+    async def set_coordinates(
+        self,
+        location_id: UUID,
+        tenant_id: UUID,
+        lat: float,
+        lng: float,
+        source: str,
+    ) -> Location:
+        """Persist coordinates with status ``ok``."""
+        return await self.update(
+            location_id,
+            tenant_id,
+            lat=Decimal(str(lat)),
+            lng=Decimal(str(lng)),
+            geocode_source=source,
+            geocode_status="ok",
+            geocoded_at=datetime.now(UTC),
+        )
+
+    async def mark_geocode_failed(
+        self, location_id: UUID, tenant_id: UUID, error: str
+    ) -> Location:
+        """Mark this location as having failed geocoding."""
+        # ``error`` is logged at the service layer; we just store the status
+        # transition here.
+        del error
+        return await self.update(
+            location_id,
+            tenant_id,
+            geocode_status="failed",
+            geocoded_at=datetime.now(UTC),
+        )
+
+    async def archive(self, location_id: UUID, tenant_id: UUID) -> Location:
+        """Soft-delete a location."""
+        return await self.update(location_id, tenant_id, archived=True)
+
+
+class InMemoryLocationRepository:
+    """In-memory mock implementing :class:`LocationRepositoryProtocol`."""
+
+    def __init__(self) -> None:
+        self._rows: dict[UUID, dict[str, Any]] = {}
+
+    def _row_to_location(self, row: dict[str, Any]) -> Location:
+        loc = Location(
+            id=row["id"],
+            tenant_id=row["tenant_id"],
+            customer_id=row["customer_id"],
+            label=row.get("label"),
+            street=row["street"],
+            street2=row.get("street2"),
+            city=row["city"],
+            state=row["state"],
+            postal_code=row["postal_code"],
+            country=row.get("country", "US"),
+            lat=row.get("lat"),
+            lng=row.get("lng"),
+            geocode_source=row.get("geocode_source"),
+            geocode_status=row.get("geocode_status", "pending"),
+            geocoded_at=row.get("geocoded_at"),
+            archived=row.get("archived", False),
+        )
+        loc.created_at = row["created_at"]
+        loc.updated_at = row["updated_at"]
+        return loc
+
+    async def create(
+        self,
+        tenant_id: UUID,
+        customer_id: UUID,
+        *,
+        street: str,
+        city: str,
+        state: str,
+        postal_code: str,
+        country: str = "US",
+        street2: str | None = None,
+        label: str | None = None,
+    ) -> Location:
+        """Insert a fresh location."""
+        lid = uuid4()
+        now = datetime.now(UTC)
+        self._rows[lid] = {
+            "id": lid,
+            "tenant_id": tenant_id,
+            "customer_id": customer_id,
+            "label": label,
+            "street": street,
+            "street2": street2,
+            "city": city,
+            "state": state,
+            "postal_code": postal_code,
+            "country": country,
+            "lat": None,
+            "lng": None,
+            "geocode_source": None,
+            "geocode_status": "pending",
+            "geocoded_at": None,
+            "archived": False,
+            "created_at": now,
+            "updated_at": now,
+        }
+        return self._row_to_location(self._rows[lid])
+
+    async def get_by_id(self, location_id: UUID, tenant_id: UUID) -> Location | None:
+        """Tenant-scoped read."""
+        row = self._rows.get(location_id)
+        if row is None or row["tenant_id"] != tenant_id:
+            return None
+        return self._row_to_location(row)
+
+    async def list_for_customer(
+        self,
+        customer_id: UUID,
+        tenant_id: UUID,
+        *,
+        archived: bool = False,
+    ) -> list[Location]:
+        """List locations belonging to the customer."""
+        rows = [
+            r
+            for r in self._rows.values()
+            if r["tenant_id"] == tenant_id
+            and r["customer_id"] == customer_id
+            and r["archived"] == archived
+        ]
+        rows.sort(key=lambda r: r["created_at"])
+        return [self._row_to_location(r) for r in rows]
+
+    async def list_pending_geocode(
+        self, tenant_id: UUID, limit: int = 50
+    ) -> list[Location]:
+        """Return up to ``limit`` rows still pending geocode."""
+        rows = [
+            r
+            for r in self._rows.values()
+            if r["tenant_id"] == tenant_id and r["geocode_status"] == "pending"
+        ]
+        rows.sort(key=lambda r: r["created_at"])
+        return [self._row_to_location(r) for r in rows[:limit]]
+
+    async def update(self, location_id: UUID, tenant_id: UUID, **patch: Any) -> Location:
+        """Apply a partial update; raises if cross-tenant or absent."""
+        row = self._rows.get(location_id)
+        if row is None or row["tenant_id"] != tenant_id:
+            raise LocationNotFoundError(f"Location {location_id} not found")
+        for key, value in deepcopy(patch).items():
+            row[key] = value
+        row["updated_at"] = datetime.now(UTC)
+        return self._row_to_location(row)
+
+    async def set_coordinates(
+        self,
+        location_id: UUID,
+        tenant_id: UUID,
+        lat: float,
+        lng: float,
+        source: str,
+    ) -> Location:
+        """Persist coordinates and flip status to ``ok``."""
+        return await self.update(
+            location_id,
+            tenant_id,
+            lat=Decimal(str(lat)),
+            lng=Decimal(str(lng)),
+            geocode_source=source,
+            geocode_status="ok",
+            geocoded_at=datetime.now(UTC),
+        )
+
+    async def mark_geocode_failed(
+        self, location_id: UUID, tenant_id: UUID, error: str
+    ) -> Location:
+        """Flip status to ``failed``; ``error`` is logged at the service layer."""
+        del error
+        return await self.update(
+            location_id,
+            tenant_id,
+            geocode_status="failed",
+            geocoded_at=datetime.now(UTC),
+        )
+
+    async def archive(self, location_id: UUID, tenant_id: UUID) -> Location:
+        """Soft-delete a location."""
+        return await self.update(location_id, tenant_id, archived=True)

--- a/src/office_hero/repositories/location_repository.py
+++ b/src/office_hero/repositories/location_repository.py
@@ -43,9 +43,7 @@ class LocationRepositoryProtocol(Protocol):
         archived: bool = False,
     ) -> list[Location]: ...
 
-    async def list_pending_geocode(
-        self, tenant_id: UUID, limit: int = 50
-    ) -> list[Location]: ...
+    async def list_pending_geocode(self, tenant_id: UUID, limit: int = 50) -> list[Location]: ...
 
     async def update(self, location_id: UUID, tenant_id: UUID, **patch: Any) -> Location: ...
 
@@ -105,9 +103,7 @@ class LocationRepository:
 
     async def get_by_id(self, location_id: UUID, tenant_id: UUID) -> Location | None:
         """Tenant-scoped read."""
-        stmt = select(Location).where(
-            Location.id == location_id, Location.tenant_id == tenant_id
-        )
+        stmt = select(Location).where(Location.id == location_id, Location.tenant_id == tenant_id)
         return (await self.session.execute(stmt)).scalars().first()
 
     async def list_for_customer(
@@ -129,9 +125,7 @@ class LocationRepository:
         )
         return list((await self.session.execute(stmt)).scalars().all())
 
-    async def list_pending_geocode(
-        self, tenant_id: UUID, limit: int = 50
-    ) -> list[Location]:
+    async def list_pending_geocode(self, tenant_id: UUID, limit: int = 50) -> list[Location]:
         """Worker hook — fetch rows the geocoder still needs to resolve."""
         stmt = (
             select(Location)
@@ -173,9 +167,7 @@ class LocationRepository:
             geocoded_at=datetime.now(UTC),
         )
 
-    async def mark_geocode_failed(
-        self, location_id: UUID, tenant_id: UUID, error: str
-    ) -> Location:
+    async def mark_geocode_failed(self, location_id: UUID, tenant_id: UUID, error: str) -> Location:
         """Mark this location as having failed geocoding."""
         # ``error`` is logged at the service layer; we just store the status
         # transition here.
@@ -284,9 +276,7 @@ class InMemoryLocationRepository:
         rows.sort(key=lambda r: r["created_at"])
         return [self._row_to_location(r) for r in rows]
 
-    async def list_pending_geocode(
-        self, tenant_id: UUID, limit: int = 50
-    ) -> list[Location]:
+    async def list_pending_geocode(self, tenant_id: UUID, limit: int = 50) -> list[Location]:
         """Return up to ``limit`` rows still pending geocode."""
         rows = [
             r
@@ -325,9 +315,7 @@ class InMemoryLocationRepository:
             geocoded_at=datetime.now(UTC),
         )
 
-    async def mark_geocode_failed(
-        self, location_id: UUID, tenant_id: UUID, error: str
-    ) -> Location:
+    async def mark_geocode_failed(self, location_id: UUID, tenant_id: UUID, error: str) -> Location:
         """Flip status to ``failed``; ``error`` is logged at the service layer."""
         del error
         return await self.update(

--- a/src/office_hero/repositories/mocks.py
+++ b/src/office_hero/repositories/mocks.py
@@ -2,11 +2,56 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID, uuid4
 
 from office_hero.sagas.core import SagaContext, SagaStatus
+
+
+@dataclass
+class AuditEvent:
+    """Captured audit event for use in unit tests."""
+
+    event_type: str
+    details: dict
+    tenant_id: UUID
+    user_id: UUID | None = None
+    request_id: UUID | None = None
+
+
+class InMemoryAuditService:
+    """In-memory audit publisher that just captures events for unit tests.
+
+    Implements the ``log_event`` contract used by the customer / location
+    services. Production code wires the real :class:`AuditService` from
+    ``services.audit_service`` which persists rows to the ``audit_events``
+    table.
+    """
+
+    def __init__(self) -> None:
+        """Initialise an empty event log."""
+        self.events: list[AuditEvent] = []
+
+    async def log_event(
+        self,
+        event_type: str,
+        details: dict,
+        tenant_id: UUID,
+        user_id: UUID | None = None,
+        request_id: UUID | None = None,
+    ) -> None:
+        """Capture an audit event in the in-memory log."""
+        self.events.append(
+            AuditEvent(
+                event_type=event_type,
+                details=details,
+                tenant_id=tenant_id,
+                user_id=user_id,
+                request_id=request_id,
+            )
+        )
 
 
 class MockSagaRepository:

--- a/src/office_hero/services/customer_service.py
+++ b/src/office_hero/services/customer_service.py
@@ -11,12 +11,13 @@ from __future__ import annotations
 from typing import Any, Protocol
 from uuid import UUID
 
-from office_hero.core.exceptions import CustomerNotFoundError, DuplicateEmailError
+from office_hero.core.exceptions import CustomerNotFoundError
 from office_hero.core.logging import get_logger
 from office_hero.models.customer import Customer
 from office_hero.repositories.customer_repository import (
     CustomerRepositoryProtocol,
 )
+
 # Type alias for the richer list-with-location-stats return
 CustomerSummaryRow = tuple[Customer, int, str | None]
 

--- a/src/office_hero/services/customer_service.py
+++ b/src/office_hero/services/customer_service.py
@@ -11,12 +11,14 @@ from __future__ import annotations
 from typing import Any, Protocol
 from uuid import UUID
 
-from office_hero.core.exceptions import CustomerNotFoundError
+from office_hero.core.exceptions import CustomerNotFoundError, DuplicateEmailError
 from office_hero.core.logging import get_logger
 from office_hero.models.customer import Customer
 from office_hero.repositories.customer_repository import (
     CustomerRepositoryProtocol,
 )
+# Type alias for the richer list-with-location-stats return
+CustomerSummaryRow = tuple[Customer, int, str | None]
 
 log = get_logger(__name__)
 
@@ -135,6 +137,20 @@ class CustomerService:
     ) -> tuple[list[Customer], int]:
         """Return ``(rows, total)`` for a tenant, filtered."""
         return await self.repo.list(
+            tenant_id, search=search, archived=archived, limit=limit, offset=offset
+        )
+
+    async def list_summaries(
+        self,
+        tenant_id: UUID,
+        *,
+        search: str | None = None,
+        archived: bool = False,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[CustomerSummaryRow], int]:
+        """Return ``(rows, total)`` where each row includes location_count and primary_city."""
+        return await self.repo.list_summaries(
             tenant_id, search=search, archived=archived, limit=limit, offset=offset
         )
 

--- a/src/office_hero/services/customer_service.py
+++ b/src/office_hero/services/customer_service.py
@@ -1,0 +1,203 @@
+"""CustomerService — orchestrates customer CRUD and emits audit events.
+
+The service depends on a :class:`CustomerRepositoryProtocol` and an audit
+publisher with the ``log_event`` method shape established in slice 4. Audit
+payloads must never carry raw PII unnecessarily — long free-text ``notes``
+fields are truncated before being recorded.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+from uuid import UUID
+
+from office_hero.core.exceptions import CustomerNotFoundError
+from office_hero.core.logging import get_logger
+from office_hero.models.customer import Customer
+from office_hero.repositories.customer_repository import (
+    CustomerRepositoryProtocol,
+)
+
+log = get_logger(__name__)
+
+
+_NOTES_MAX_LEN_IN_AUDIT = 256
+
+
+class AuditPublisher(Protocol):
+    """Minimal audit-publisher contract the service depends on (ADR 063)."""
+
+    async def log_event(
+        self,
+        event_type: str,
+        details: dict,
+        tenant_id: UUID,
+        user_id: UUID | None = None,
+        request_id: UUID | None = None,
+    ) -> None: ...
+
+
+def _truncate_notes_value(value: Any) -> Any:
+    """Return ``value`` truncated if it's a long free-text notes string."""
+    if isinstance(value, str) and len(value) > _NOTES_MAX_LEN_IN_AUDIT:
+        return value[:_NOTES_MAX_LEN_IN_AUDIT] + "...[truncated]"
+    return value
+
+
+def _redact_notes(details: dict[str, Any]) -> dict[str, Any]:
+    """Truncate any ``notes`` strings (top-level or inside before/after).
+
+    Audit details may contain ``notes`` directly (create) or inside a diff
+    bag (``before``/``after`` from update). Both shapes are handled here so
+    PII can't sneak through one path.
+    """
+    if "notes" in details:
+        details["notes"] = _truncate_notes_value(details["notes"])
+    for bag_key in ("before", "after"):
+        bag = details.get(bag_key)
+        if isinstance(bag, dict) and "notes" in bag:
+            bag["notes"] = _truncate_notes_value(bag["notes"])
+    return details
+
+
+def _customer_summary(cust: Customer) -> dict[str, Any]:
+    """Audit-safe customer projection (no notes/email-detail)."""
+    return {
+        "customer_id": str(cust.id),
+        "name": cust.name,
+        "archived": cust.archived,
+    }
+
+
+class CustomerService:
+    """Business orchestration for the :class:`Customer` aggregate."""
+
+    def __init__(
+        self,
+        repo: CustomerRepositoryProtocol,
+        audit: AuditPublisher,
+    ):
+        """Inject the repository and the audit publisher (DI)."""
+        self.repo = repo
+        self.audit = audit
+
+    async def create(
+        self,
+        tenant_id: UUID,
+        user_id: UUID,
+        *,
+        name: str,
+        email: str | None = None,
+        phone: str | None = None,
+        notes: str | None = None,
+        external_id: str | None = None,
+    ) -> Customer:
+        """Create a customer; emit ``customer.created``."""
+        cust = await self.repo.create(
+            tenant_id,
+            name=name,
+            email=email,
+            phone=phone,
+            notes=notes,
+            external_id=external_id,
+        )
+        details = _redact_notes(
+            {
+                **_customer_summary(cust),
+                "email": email,
+                "phone": phone,
+                "notes": notes,
+            }
+        )
+        await self.audit.log_event(
+            event_type="customer.created",
+            details=details,
+            tenant_id=tenant_id,
+            user_id=user_id,
+        )
+        return cust
+
+    async def get(self, tenant_id: UUID, customer_id: UUID) -> Customer:
+        """Fetch a customer or raise :class:`CustomerNotFoundError`."""
+        cust = await self.repo.get_by_id(customer_id, tenant_id)
+        if cust is None:
+            raise CustomerNotFoundError(f"Customer {customer_id} not found")
+        return cust
+
+    async def list(
+        self,
+        tenant_id: UUID,
+        *,
+        search: str | None = None,
+        archived: bool = False,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[Customer], int]:
+        """Return ``(rows, total)`` for a tenant, filtered."""
+        return await self.repo.list(
+            tenant_id, search=search, archived=archived, limit=limit, offset=offset
+        )
+
+    async def update(
+        self,
+        tenant_id: UUID,
+        user_id: UUID,
+        customer_id: UUID,
+        patch: dict[str, Any],
+    ) -> Customer:
+        """Update a customer; emit ``customer.updated`` with the diff."""
+        existing = await self.get(tenant_id, customer_id)
+
+        before: dict[str, Any] = {}
+        after: dict[str, Any] = {}
+        for key, value in patch.items():
+            current = getattr(existing, key, None)
+            if current != value:
+                before[key] = current
+                after[key] = value
+
+        updated = await self.repo.update(customer_id, tenant_id, **patch)
+        details = _redact_notes(
+            {
+                "customer_id": str(updated.id),
+                "before": before,
+                "after": after,
+            }
+        )
+        await self.audit.log_event(
+            event_type="customer.updated",
+            details=details,
+            tenant_id=tenant_id,
+            user_id=user_id,
+        )
+        return updated
+
+    async def archive(
+        self, tenant_id: UUID, user_id: UUID, customer_id: UUID
+    ) -> Customer:
+        """Soft-delete; emit ``customer.archived``."""
+        # Make sure it exists in this tenant first so we surface a clean
+        # CustomerNotFoundError rather than a generic repo error.
+        await self.get(tenant_id, customer_id)
+        archived = await self.repo.archive(customer_id, tenant_id)
+        await self.audit.log_event(
+            event_type="customer.archived",
+            details=_customer_summary(archived),
+            tenant_id=tenant_id,
+            user_id=user_id,
+        )
+        return archived
+
+    async def restore(
+        self, tenant_id: UUID, user_id: UUID, customer_id: UUID
+    ) -> Customer:
+        """Clear archived; emit ``customer.restored``."""
+        await self.get(tenant_id, customer_id)
+        restored = await self.repo.restore(customer_id, tenant_id)
+        await self.audit.log_event(
+            event_type="customer.restored",
+            details=_customer_summary(restored),
+            tenant_id=tenant_id,
+            user_id=user_id,
+        )
+        return restored

--- a/src/office_hero/services/customer_service.py
+++ b/src/office_hero/services/customer_service.py
@@ -172,9 +172,7 @@ class CustomerService:
         )
         return updated
 
-    async def archive(
-        self, tenant_id: UUID, user_id: UUID, customer_id: UUID
-    ) -> Customer:
+    async def archive(self, tenant_id: UUID, user_id: UUID, customer_id: UUID) -> Customer:
         """Soft-delete; emit ``customer.archived``."""
         # Make sure it exists in this tenant first so we surface a clean
         # CustomerNotFoundError rather than a generic repo error.
@@ -188,9 +186,7 @@ class CustomerService:
         )
         return archived
 
-    async def restore(
-        self, tenant_id: UUID, user_id: UUID, customer_id: UUID
-    ) -> Customer:
+    async def restore(self, tenant_id: UUID, user_id: UUID, customer_id: UUID) -> Customer:
         """Clear archived; emit ``customer.restored``."""
         await self.get(tenant_id, customer_id)
         restored = await self.repo.restore(customer_id, tenant_id)

--- a/src/office_hero/services/location_service.py
+++ b/src/office_hero/services/location_service.py
@@ -64,9 +64,7 @@ class LocationService:
         """Raise :class:`CustomerNotFoundError` if customer is missing or cross-tenant."""
         cust = await self.customer_repo.get_by_id(customer_id, tenant_id)
         if cust is None:
-            raise CustomerNotFoundError(
-                f"Customer {customer_id} not found in tenant scope"
-            )
+            raise CustomerNotFoundError(f"Customer {customer_id} not found in tenant scope")
 
     async def create(
         self,
@@ -104,9 +102,7 @@ class LocationService:
         )
         return loc
 
-    async def _geocode_and_persist(
-        self, tenant_id: UUID, loc: Location
-    ) -> Location:
+    async def _geocode_and_persist(self, tenant_id: UUID, loc: Location) -> Location:
         """Try geocoding ``loc``; persist coords on success, mark failed otherwise."""
         address = AddressInput(
             street=loc.street,
@@ -127,9 +123,7 @@ class LocationService:
 
         if coords is None:
             log.info("location.geocode.miss", location_id=str(loc.id))
-            return await self.repo.mark_geocode_failed(
-                loc.id, tenant_id, "no result"
-            )
+            return await self.repo.mark_geocode_failed(loc.id, tenant_id, "no result")
 
         return await self.repo.set_coordinates(
             loc.id, tenant_id, coords.lat, coords.lng, coords.source
@@ -151,9 +145,7 @@ class LocationService:
     ) -> list[Location]:
         """List a customer's locations."""
         await self._verify_customer(tenant_id, customer_id)
-        return await self.repo.list_for_customer(
-            customer_id, tenant_id, archived=archived
-        )
+        return await self.repo.list_for_customer(customer_id, tenant_id, archived=archived)
 
     async def update(
         self,
@@ -167,9 +159,7 @@ class LocationService:
         """Apply a partial update; optionally re-geocode and emit ``location.updated``."""
         existing = await self.get(tenant_id, location_id)
 
-        changed_fields = {
-            k for k, v in patch.items() if getattr(existing, k, None) != v
-        }
+        changed_fields = {k for k, v in patch.items() if getattr(existing, k, None) != v}
 
         before: dict[str, Any] = {k: getattr(existing, k, None) for k in changed_fields}
         after: dict[str, Any] = {k: patch[k] for k in changed_fields}
@@ -233,9 +223,7 @@ class LocationService:
         )
         return updated
 
-    async def regeocode(
-        self, tenant_id: UUID, user_id: UUID, location_id: UUID
-    ) -> Location:
+    async def regeocode(self, tenant_id: UUID, user_id: UUID, location_id: UUID) -> Location:
         """Force a re-geocode of an existing location."""
         existing = await self.get(tenant_id, location_id)
         updated = await self._geocode_and_persist(tenant_id, existing)
@@ -247,9 +235,7 @@ class LocationService:
         )
         return updated
 
-    async def archive(
-        self, tenant_id: UUID, user_id: UUID, location_id: UUID
-    ) -> Location:
+    async def archive(self, tenant_id: UUID, user_id: UUID, location_id: UUID) -> Location:
         """Soft-delete a location; emit ``location.archived``."""
         await self.get(tenant_id, location_id)
         archived = await self.repo.archive(location_id, tenant_id)

--- a/src/office_hero/services/location_service.py
+++ b/src/office_hero/services/location_service.py
@@ -1,0 +1,262 @@
+"""LocationService — orchestrates location CRUD, geocoding, and audit emission."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+from uuid import UUID
+
+from office_hero.adapters.geocoding.protocol import AddressInput, GeocodingAdapter
+from office_hero.core.exceptions import (
+    CustomerNotFoundError,
+    GeocodingError,
+    LocationNotFoundError,
+)
+from office_hero.core.logging import get_logger
+from office_hero.models.location import Location
+from office_hero.repositories.customer_repository import (
+    CustomerRepositoryProtocol,
+)
+from office_hero.repositories.location_repository import (
+    LocationRepositoryProtocol,
+)
+from office_hero.services.customer_service import AuditPublisher
+
+log = get_logger(__name__)
+
+
+# Address fields that, when changed, should trigger automatic re-geocoding.
+_GEOCODE_RELEVANT_FIELDS = frozenset(
+    {"street", "street2", "city", "state", "postal_code", "country"}
+)
+
+
+def _location_summary(loc: Location) -> dict[str, Any]:
+    """Audit-safe projection of a Location."""
+    return {
+        "location_id": str(loc.id),
+        "customer_id": str(loc.customer_id),
+        "label": loc.label,
+        "city": loc.city,
+        "state": loc.state,
+        "country": loc.country,
+        "geocode_status": loc.geocode_status,
+        "geocode_source": loc.geocode_source,
+    }
+
+
+class LocationService:
+    """Business orchestration for the :class:`Location` aggregate."""
+
+    def __init__(
+        self,
+        repo: LocationRepositoryProtocol,
+        customer_repo: CustomerRepositoryProtocol,
+        audit: AuditPublisher,
+        geocoder: GeocodingAdapter,
+    ):
+        """Inject deps (DI)."""
+        self.repo = repo
+        self.customer_repo = customer_repo
+        self.audit = audit
+        self.geocoder = geocoder
+
+    async def _verify_customer(self, tenant_id: UUID, customer_id: UUID) -> None:
+        """Raise :class:`CustomerNotFoundError` if customer is missing or cross-tenant."""
+        cust = await self.customer_repo.get_by_id(customer_id, tenant_id)
+        if cust is None:
+            raise CustomerNotFoundError(
+                f"Customer {customer_id} not found in tenant scope"
+            )
+
+    async def create(
+        self,
+        tenant_id: UUID,
+        user_id: UUID,
+        customer_id: UUID,
+        address_fields: dict[str, Any],
+        label: str | None,
+        *,
+        geocode: bool = True,
+    ) -> Location:
+        """Insert a location, attempt geocoding, emit ``location.created``."""
+        await self._verify_customer(tenant_id, customer_id)
+
+        loc = await self.repo.create(
+            tenant_id,
+            customer_id,
+            street=address_fields["street"],
+            street2=address_fields.get("street2"),
+            city=address_fields["city"],
+            state=address_fields["state"],
+            postal_code=address_fields["postal_code"],
+            country=address_fields.get("country", "US"),
+            label=label,
+        )
+
+        if geocode:
+            loc = await self._geocode_and_persist(tenant_id, loc)
+
+        await self.audit.log_event(
+            event_type="location.created",
+            details=_location_summary(loc),
+            tenant_id=tenant_id,
+            user_id=user_id,
+        )
+        return loc
+
+    async def _geocode_and_persist(
+        self, tenant_id: UUID, loc: Location
+    ) -> Location:
+        """Try geocoding ``loc``; persist coords on success, mark failed otherwise."""
+        address = AddressInput(
+            street=loc.street,
+            city=loc.city,
+            state=loc.state,
+            postal_code=loc.postal_code,
+            country=loc.country,
+        )
+        try:
+            coords = await self.geocoder.geocode(address)
+        except GeocodingError as exc:
+            log.warning(
+                "location.geocode.error",
+                location_id=str(loc.id),
+                error=str(exc),
+            )
+            return await self.repo.mark_geocode_failed(loc.id, tenant_id, str(exc))
+
+        if coords is None:
+            log.info("location.geocode.miss", location_id=str(loc.id))
+            return await self.repo.mark_geocode_failed(
+                loc.id, tenant_id, "no result"
+            )
+
+        return await self.repo.set_coordinates(
+            loc.id, tenant_id, coords.lat, coords.lng, coords.source
+        )
+
+    async def get(self, tenant_id: UUID, location_id: UUID) -> Location:
+        """Fetch or raise :class:`LocationNotFoundError`."""
+        loc = await self.repo.get_by_id(location_id, tenant_id)
+        if loc is None:
+            raise LocationNotFoundError(f"Location {location_id} not found")
+        return loc
+
+    async def list_for_customer(
+        self,
+        tenant_id: UUID,
+        customer_id: UUID,
+        *,
+        archived: bool = False,
+    ) -> list[Location]:
+        """List a customer's locations."""
+        await self._verify_customer(tenant_id, customer_id)
+        return await self.repo.list_for_customer(
+            customer_id, tenant_id, archived=archived
+        )
+
+    async def update(
+        self,
+        tenant_id: UUID,
+        user_id: UUID,
+        location_id: UUID,
+        patch: dict[str, Any],
+        *,
+        regeocode: bool | Literal["auto"] = "auto",
+    ) -> Location:
+        """Apply a partial update; optionally re-geocode and emit ``location.updated``."""
+        existing = await self.get(tenant_id, location_id)
+
+        changed_fields = {
+            k for k, v in patch.items() if getattr(existing, k, None) != v
+        }
+
+        before: dict[str, Any] = {k: getattr(existing, k, None) for k in changed_fields}
+        after: dict[str, Any] = {k: patch[k] for k in changed_fields}
+
+        updated = await self.repo.update(location_id, tenant_id, **patch)
+
+        # Decide whether to re-geocode.
+        should_regeo = False
+        if regeocode is True:
+            should_regeo = True
+        elif regeocode == "auto":
+            should_regeo = bool(changed_fields & _GEOCODE_RELEVANT_FIELDS)
+        elif regeocode is False:
+            should_regeo = False
+
+        if should_regeo:
+            updated = await self._geocode_and_persist(tenant_id, updated)
+
+        await self.audit.log_event(
+            event_type="location.updated",
+            details={
+                "location_id": str(updated.id),
+                "before": before,
+                "after": after,
+                "regeocoded": should_regeo,
+                "geocode_status": updated.geocode_status,
+            },
+            tenant_id=tenant_id,
+            user_id=user_id,
+        )
+        return updated
+
+    async def manual_set_coordinates(
+        self,
+        tenant_id: UUID,
+        user_id: UUID,
+        location_id: UUID,
+        lat: float,
+        lng: float,
+    ) -> Location:
+        """Operator override of geocoded coordinates."""
+        # Existence check (raises if missing/cross-tenant).
+        await self.get(tenant_id, location_id)
+        updated = await self.repo.update(
+            location_id,
+            tenant_id,
+            lat=lat,
+            lng=lng,
+            geocode_source="manual",
+            geocode_status="manual",
+        )
+        await self.audit.log_event(
+            event_type="location.coordinates_set_manual",
+            details={
+                "location_id": str(updated.id),
+                "lat": float(lat),
+                "lng": float(lng),
+            },
+            tenant_id=tenant_id,
+            user_id=user_id,
+        )
+        return updated
+
+    async def regeocode(
+        self, tenant_id: UUID, user_id: UUID, location_id: UUID
+    ) -> Location:
+        """Force a re-geocode of an existing location."""
+        existing = await self.get(tenant_id, location_id)
+        updated = await self._geocode_and_persist(tenant_id, existing)
+        await self.audit.log_event(
+            event_type="location.regeocoded",
+            details=_location_summary(updated),
+            tenant_id=tenant_id,
+            user_id=user_id,
+        )
+        return updated
+
+    async def archive(
+        self, tenant_id: UUID, user_id: UUID, location_id: UUID
+    ) -> Location:
+        """Soft-delete a location; emit ``location.archived``."""
+        await self.get(tenant_id, location_id)
+        archived = await self.repo.archive(location_id, tenant_id)
+        await self.audit.log_event(
+            event_type="location.archived",
+            details=_location_summary(archived),
+            tenant_id=tenant_id,
+            user_id=user_id,
+        )
+        return archived

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -8,6 +8,7 @@ permission/role dependencies.
 
 from __future__ import annotations
 
+import contextlib
 from collections.abc import Iterator
 from typing import Any
 from uuid import UUID, uuid4
@@ -59,19 +60,15 @@ def _hard_reset_limiter() -> None:
     if storage is None:
         return
     if hasattr(storage, "reset"):
-        try:
+        with contextlib.suppress(Exception):
             storage.reset()
-        except Exception:  # noqa: BLE001 - best-effort reset
-            pass
     # Belt-and-braces — clear the in-memory Counter/dicts the FixedWindow
     # ratelimiter actually queries.
     for attr in ("storage", "events", "locks", "expirations"):
         bucket = getattr(storage, attr, None)
         if hasattr(bucket, "clear"):
-            try:
+            with contextlib.suppress(Exception):
                 bucket.clear()
-            except Exception:  # noqa: BLE001
-                pass
 
 
 @pytest.fixture(autouse=True)

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,210 @@
+"""Shared fixtures for the slice-9 API tests.
+
+Bypasses the JWT middleware (which is not installed in test apps) by adding a
+test-only middleware that pulls auth context from request headers. This keeps
+the test request-construction simple while still exercising the real
+permission/role dependencies.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from office_hero.adapters.geocoding.stub import StubGeocodingAdapter
+from office_hero.api.app import create_app
+from office_hero.api.limiter import limiter
+from office_hero.repositories.customer_repository import (
+    InMemoryCustomerRepository,
+)
+from office_hero.repositories.location_repository import (
+    InMemoryLocationRepository,
+)
+from office_hero.repositories.mocks import InMemoryAuditService
+from office_hero.services.customer_service import CustomerService
+from office_hero.services.location_service import LocationService
+
+
+class _TestAuthMiddleware(BaseHTTPMiddleware):
+    """Populate ``request.state`` from ``X-Test-*`` headers (test only)."""
+
+    async def dispatch(self, request: Request, call_next):
+        request.state.tenant_id = request.headers.get("X-Test-Tenant-Id")
+        request.state.user_id = request.headers.get("X-Test-User-Id")
+        request.state.role = request.headers.get("X-Test-Role", "tenant_admin")
+        perms = request.headers.get("X-Test-Permissions", "customers:read,customers:write")
+        request.state.permissions = [p.strip() for p in perms.split(",") if p.strip()]
+        return await call_next(request)
+
+
+def _hard_reset_limiter() -> None:
+    """Reset both the slowapi limiter and the underlying MemoryStorage.
+
+    ``Limiter.reset`` only clears its in-Limiter caches; the bucket counts
+    live in ``limiter.limiter.storage`` and need an explicit ``.reset()``
+    to make per-IP/endpoint buckets forget across tests.
+
+    The MemoryStorage's ``Counter`` keeps stale entries between tests
+    despite ``reset()``, so we also nuke the events/locks dicts directly
+    when the storage exposes them.
+    """
+    limiter.reset()
+    storage = getattr(getattr(limiter, "limiter", None), "storage", None)
+    if storage is None:
+        return
+    if hasattr(storage, "reset"):
+        try:
+            storage.reset()
+        except Exception:  # noqa: BLE001 - best-effort reset
+            pass
+    # Belt-and-braces — clear the in-memory Counter/dicts the FixedWindow
+    # ratelimiter actually queries.
+    for attr in ("storage", "events", "locks", "expirations"):
+        bucket = getattr(storage, attr, None)
+        if hasattr(bucket, "clear"):
+            try:
+                bucket.clear()
+            except Exception:  # noqa: BLE001
+                pass
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter() -> Iterator[None]:
+    """Reset the slowapi limiter between tests so per-IP buckets don't leak.
+
+    Some tests legitimately exercise the limiter (e.g. a future "exceeds
+    write tier" test), but the default fixture clears state at both ends
+    so a noisy neighbour can't fail the next test.
+    """
+    _hard_reset_limiter()
+    yield
+    _hard_reset_limiter()
+
+
+@pytest.fixture()
+def disabled_limiter() -> Iterator[None]:
+    """Test override that turns the slowapi limiter off for the duration."""
+    prior = limiter.enabled
+    limiter.enabled = False
+    try:
+        yield
+    finally:
+        limiter.enabled = prior
+        _hard_reset_limiter()
+
+
+@pytest.fixture()
+def tenant_a() -> UUID:
+    return uuid4()
+
+
+@pytest.fixture()
+def tenant_b() -> UUID:
+    return uuid4()
+
+
+@pytest.fixture()
+def user_a() -> UUID:
+    return uuid4()
+
+
+@pytest.fixture()
+def auth() -> InMemoryAuditService:
+    return InMemoryAuditService()
+
+
+@pytest.fixture()
+def cust_repo() -> InMemoryCustomerRepository:
+    return InMemoryCustomerRepository()
+
+
+@pytest.fixture()
+def loc_repo() -> InMemoryLocationRepository:
+    return InMemoryLocationRepository()
+
+
+@pytest.fixture()
+def geocoder() -> StubGeocodingAdapter:
+    return StubGeocodingAdapter()
+
+
+@pytest.fixture()
+def customer_service(cust_repo, auth) -> CustomerService:
+    return CustomerService(repo=cust_repo, audit=auth)
+
+
+@pytest.fixture()
+def location_service(loc_repo, cust_repo, auth, geocoder) -> LocationService:
+    return LocationService(
+        repo=loc_repo,
+        customer_repo=cust_repo,
+        audit=auth,
+        geocoder=geocoder,
+    )
+
+
+def _build_app(customer_service, location_service) -> FastAPI:
+    app = create_app(
+        customer_service=customer_service,
+        location_service=location_service,
+    )
+    app.add_middleware(_TestAuthMiddleware)
+    return app
+
+
+@pytest.fixture()
+def app(customer_service, location_service) -> FastAPI:
+    return _build_app(customer_service, location_service)
+
+
+@pytest.fixture()
+def client(app) -> Iterator[TestClient]:
+    with TestClient(app) as c:
+        yield c
+
+
+def auth_headers(
+    tenant_id: UUID,
+    user_id: UUID,
+    *,
+    role: str = "tenant_admin",
+    permissions: str = "customers:read,customers:write",
+) -> dict[str, str]:
+    """Build the X-Test-* header bag the test middleware reads."""
+    return {
+        "X-Test-Tenant-Id": str(tenant_id),
+        "X-Test-User-Id": str(user_id),
+        "X-Test-Role": role,
+        "X-Test-Permissions": permissions,
+    }
+
+
+def technician_headers(tenant_id: UUID, user_id: UUID) -> dict[str, str]:
+    """A Technician has read-only customers permission and a non-admin role."""
+    return auth_headers(
+        tenant_id,
+        user_id,
+        role="technician",
+        permissions="customers:read",
+    )
+
+
+def sales_headers(tenant_id: UUID, user_id: UUID) -> dict[str, str]:
+    """Sales role lacks ``customers:write``."""
+    return auth_headers(
+        tenant_id,
+        user_id,
+        role="sales",
+        permissions="customers:read",
+    )
+
+
+def unauthenticated_headers() -> dict[str, Any]:
+    """No auth headers — middleware will leave request.state empty."""
+    return {}

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -117,13 +117,13 @@ def auth() -> InMemoryAuditService:
 
 
 @pytest.fixture()
-def cust_repo() -> InMemoryCustomerRepository:
-    return InMemoryCustomerRepository()
+def loc_repo() -> InMemoryLocationRepository:
+    return InMemoryLocationRepository()
 
 
 @pytest.fixture()
-def loc_repo() -> InMemoryLocationRepository:
-    return InMemoryLocationRepository()
+def cust_repo(loc_repo) -> InMemoryCustomerRepository:
+    return InMemoryCustomerRepository(loc_repo=loc_repo)
 
 
 @pytest.fixture()

--- a/tests/api/test_customers_api.py
+++ b/tests/api/test_customers_api.py
@@ -171,3 +171,21 @@ def test_archive_unknown_customer_returns_404(client, tenant_a, user_a):
         headers=auth_headers(tenant_a, user_a),
     )
     assert resp.status_code == 404
+
+
+def test_create_customer_duplicate_email_rejected(client, tenant_a, user_a):
+    """Creating two active customers with the same email in the same tenant returns 409."""
+    first = client.post(
+        "/customers",
+        json={"name": "Acme Plumbing", "email": "ops@acme.example"},
+        headers=auth_headers(tenant_a, user_a),
+    )
+    assert first.status_code == 201
+
+    second = client.post(
+        "/customers",
+        json={"name": "Acme Refrigeration", "email": "ops@acme.example"},
+        headers=auth_headers(tenant_a, user_a),
+    )
+    assert second.status_code == 409
+    assert "email" in second.json()["detail"].lower()

--- a/tests/api/test_customers_api.py
+++ b/tests/api/test_customers_api.py
@@ -1,0 +1,173 @@
+"""HTTP-layer tests for the /customers routes (RBAC + tenant isolation)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from tests.api.conftest import (
+    auth_headers,
+    sales_headers,
+    unauthenticated_headers,
+)
+
+
+def test_post_customer_requires_auth(client):
+    """No auth headers -> 401 Unauthorized."""
+    resp = client.post(
+        "/customers",
+        json={"name": "Acme"},
+        headers=unauthenticated_headers(),
+    )
+    # FastAPI dependencies first run permission checks (403) before tenant id is
+    # read. Either 401 or 403 are acceptable "you may not" signals — we accept
+    # both rather than encoding a specific order-of-evaluation here.
+    assert resp.status_code in (401, 403)
+
+
+def test_post_customer_wrong_permission_returns_403(client, tenant_a, user_a):
+    """Sales role without ``customers:write`` is rejected."""
+    resp = client.post(
+        "/customers",
+        json={"name": "Acme"},
+        headers=sales_headers(tenant_a, user_a),
+    )
+    assert resp.status_code == 403
+
+
+def test_post_customer_returns_201_and_id(client, tenant_a, user_a):
+    """Successful create returns 201 with a UUID id."""
+    resp = client.post(
+        "/customers",
+        json={"name": "Acme Plumbing", "email": "ops@acme.example"},
+        headers=auth_headers(tenant_a, user_a),
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["name"] == "Acme Plumbing"
+    assert body["tenant_id"] == str(tenant_a)
+    assert "id" in body
+
+
+def test_get_customer_cross_tenant_returns_404(client, tenant_a, tenant_b, user_a):
+    """Tenant B cannot see tenant A's customer; RLS-hide simulated as 404."""
+    create = client.post(
+        "/customers",
+        json={"name": "Tenant A Co"},
+        headers=auth_headers(tenant_a, user_a),
+    )
+    assert create.status_code == 201
+    cid = create.json()["id"]
+
+    resp = client.get(
+        f"/customers/{cid}",
+        headers=auth_headers(tenant_b, user_a),
+    )
+    assert resp.status_code == 404
+
+
+def test_list_customers_pagination(client, tenant_a, user_a):
+    """``limit`` and ``offset`` control the page."""
+    for i in range(5):
+        client.post(
+            "/customers",
+            json={"name": f"Cust {i}"},
+            headers=auth_headers(tenant_a, user_a),
+        )
+
+    resp = client.get(
+        "/customers?limit=2&offset=0",
+        headers=auth_headers(tenant_a, user_a),
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 5
+    assert len(body["items"]) == 2
+    assert body["limit"] == 2
+    assert body["offset"] == 0
+
+
+def test_list_customers_search(client, tenant_a, user_a):
+    """``search`` filters by case-insensitive substring on name/email."""
+    for name in ("Acme Plumbing", "Beta HVAC", "Acme Refrigeration"):
+        client.post(
+            "/customers",
+            json={"name": name},
+            headers=auth_headers(tenant_a, user_a),
+        )
+
+    resp = client.get(
+        "/customers?search=acme",
+        headers=auth_headers(tenant_a, user_a),
+    )
+    assert resp.status_code == 200
+    names = sorted(item["name"] for item in resp.json()["items"])
+    assert names == ["Acme Plumbing", "Acme Refrigeration"]
+
+
+def test_archive_then_restore_roundtrip(client, tenant_a, user_a):
+    """Archive then restore returns the customer to active state."""
+    create = client.post(
+        "/customers",
+        json={"name": "Gamma"},
+        headers=auth_headers(tenant_a, user_a),
+    )
+    cid = create.json()["id"]
+
+    arch = client.post(
+        f"/customers/{cid}/archive",
+        headers=auth_headers(tenant_a, user_a),
+    )
+    assert arch.status_code == 200
+    assert arch.json()["archived"] is True
+
+    rest = client.post(
+        f"/customers/{cid}/restore",
+        headers=auth_headers(tenant_a, user_a),
+    )
+    assert rest.status_code == 200
+    assert rest.json()["archived"] is False
+
+
+def test_patch_customer_updates_fields(client, tenant_a, user_a):
+    """PATCH applies the supplied fields and returns the new view."""
+    create = client.post(
+        "/customers",
+        json={"name": "Original Name"},
+        headers=auth_headers(tenant_a, user_a),
+    )
+    cid = create.json()["id"]
+
+    patch = client.patch(
+        f"/customers/{cid}",
+        json={"name": "Renamed", "phone": "555-1234"},
+        headers=auth_headers(tenant_a, user_a),
+    )
+    assert patch.status_code == 200
+    body = patch.json()
+    assert body["name"] == "Renamed"
+    assert body["phone"] == "555-1234"
+
+
+def test_patch_customer_empty_body_is_rejected(client, tenant_a, user_a):
+    """Empty PATCH body must be rejected by the validator (422)."""
+    create = client.post(
+        "/customers",
+        json={"name": "Original"},
+        headers=auth_headers(tenant_a, user_a),
+    )
+    cid = create.json()["id"]
+    resp = client.patch(
+        f"/customers/{cid}",
+        json={},
+        headers=auth_headers(tenant_a, user_a),
+    )
+    assert resp.status_code == 422
+
+
+def test_archive_unknown_customer_returns_404(client, tenant_a, user_a):
+    """Archiving an unknown id surfaces 404."""
+    resp = client.post(
+        f"/customers/{uuid4()}/archive",
+        headers=auth_headers(tenant_a, user_a),
+    )
+    assert resp.status_code == 404

--- a/tests/api/test_locations_api.py
+++ b/tests/api/test_locations_api.py
@@ -1,0 +1,240 @@
+"""HTTP-layer tests for /customers/{cid}/locations and /locations/{lid}.
+
+The stub geocoder is the default in ``create_app`` so no live network calls
+happen. Rate-limit assertions are kept light — slowapi may not block in the
+test client without explicit configuration, so we test the limiter is wired
+rather than enforce the exact ceiling.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from tests.api.conftest import (
+    auth_headers,
+    technician_headers,
+)
+
+
+_VALID_ADDR = {
+    "street": "123 Main St",
+    "city": "Philadelphia",
+    "state": "PA",
+    "postal_code": "19103",
+    "country": "US",
+}
+
+
+def _create_customer(client, tenant_a, user_a, name: str = "Acme") -> str:
+    resp = client.post(
+        "/customers",
+        json={"name": name},
+        headers=auth_headers(tenant_a, user_a),
+    )
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+def test_post_location_geocodes_and_returns_lat_lng(client, tenant_a, user_a):
+    """Posting a location with the stub geocoder returns ok status + coords."""
+    cid = _create_customer(client, tenant_a, user_a)
+    resp = client.post(
+        f"/customers/{cid}/locations",
+        json={**_VALID_ADDR, "label": "Main"},
+        headers=auth_headers(tenant_a, user_a),
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["geocode_status"] == "ok"
+    assert body["geocode_source"] == "stub"
+    assert body["lat"] is not None
+    assert body["lng"] is not None
+
+
+def test_post_location_geocode_failure_still_returns_201(client, tenant_a, user_a):
+    """A geocoder miss returns 201 with status=failed (the location persists)."""
+    cid = _create_customer(client, tenant_a, user_a)
+    # The stub geocoder returns None when the street contains "FAIL".
+    resp = client.post(
+        f"/customers/{cid}/locations",
+        json={**_VALID_ADDR, "street": "FAIL Lane", "label": "x"},
+        headers=auth_headers(tenant_a, user_a),
+    )
+    assert resp.status_code == 201
+    assert resp.json()["geocode_status"] == "failed"
+
+
+def test_get_locations_for_customer_other_tenant_returns_404(
+    client, tenant_a, tenant_b, user_a
+):
+    """Cross-tenant list returns 404 (silent RLS-style isolation)."""
+    cid = _create_customer(client, tenant_a, user_a)
+    resp = client.get(
+        f"/customers/{cid}/locations",
+        headers=auth_headers(tenant_b, user_a),
+    )
+    assert resp.status_code == 404
+
+
+def test_manual_coordinates_requires_dispatcher_or_admin(client, tenant_a, user_a):
+    """Technician (non-admin/non-dispatcher) cannot manually override coordinates."""
+    cid = _create_customer(client, tenant_a, user_a)
+    create = client.post(
+        f"/customers/{cid}/locations",
+        json={**_VALID_ADDR, "label": "x"},
+        headers=auth_headers(tenant_a, user_a),
+    )
+    lid = create.json()["id"]
+
+    resp = client.post(
+        f"/locations/{lid}/coordinates",
+        json={"lat": 40.0, "lng": -75.0},
+        headers=technician_headers(tenant_a, user_a),
+    )
+    assert resp.status_code == 403
+
+
+def test_manual_coordinates_admin_succeeds(client, tenant_a, user_a):
+    """A tenant admin can override coordinates manually."""
+    cid = _create_customer(client, tenant_a, user_a)
+    create = client.post(
+        f"/customers/{cid}/locations",
+        json={**_VALID_ADDR, "label": "x"},
+        headers=auth_headers(tenant_a, user_a),
+    )
+    lid = create.json()["id"]
+
+    resp = client.post(
+        f"/locations/{lid}/coordinates",
+        json={"lat": 40.0, "lng": -75.0},
+        headers=auth_headers(tenant_a, user_a),
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["geocode_source"] == "manual"
+    assert body["geocode_status"] == "manual"
+
+
+def test_patch_location_address_triggers_regeocode(client, tenant_a, user_a):
+    """PATCH with an address change updates lat/lng via the stub geocoder."""
+    cid = _create_customer(client, tenant_a, user_a)
+    create = client.post(
+        f"/customers/{cid}/locations",
+        json={**_VALID_ADDR, "label": "x"},
+        headers=auth_headers(tenant_a, user_a),
+    )
+    body0 = create.json()
+    lid = body0["id"]
+    lat0 = body0["lat"]
+
+    patch = client.patch(
+        f"/locations/{lid}",
+        json={"street": "999 Different Ave"},
+        headers=auth_headers(tenant_a, user_a),
+    )
+    assert patch.status_code == 200
+    body1 = patch.json()
+    assert body1["geocode_status"] == "ok"
+    # The stub is deterministic on ``street``, so the coords MUST differ.
+    assert body1["lat"] != lat0
+
+
+def test_regeocode_endpoint_returns_200(
+    client, tenant_a, user_a, disabled_limiter
+):
+    """Force-regeocode is exposed at POST /locations/{id}/regeocode.
+
+    The endpoint carries a 5/minute rate limit (see slice design); the
+    ``disabled_limiter`` fixture turns slowapi off for this test so we can
+    assert the happy-path response shape without colliding with the bucket
+    that other location tests may have already used inside the same
+    pytest process.
+    """
+    cid = _create_customer(client, tenant_a, user_a)
+    create = client.post(
+        f"/customers/{cid}/locations",
+        json={**_VALID_ADDR, "label": "x"},
+        headers=auth_headers(tenant_a, user_a),
+    )
+    lid = create.json()["id"]
+
+    resp = client.post(
+        f"/locations/{lid}/regeocode",
+        headers=auth_headers(tenant_a, user_a),
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["geocode_status"] in {"ok", "failed"}
+
+
+def test_regeocode_endpoint_is_rate_limited(client, tenant_a, user_a):
+    """The endpoint enforces a 5/minute rate limit (Nominatim quota protection).
+
+    Sending 6 consecutive POSTs from the same client identity should see the
+    last one rejected with 429.
+    """
+    cid = _create_customer(client, tenant_a, user_a)
+    create = client.post(
+        f"/customers/{cid}/locations",
+        json={**_VALID_ADDR, "label": "x"},
+        headers=auth_headers(tenant_a, user_a),
+    )
+    lid = create.json()["id"]
+
+    statuses = []
+    for _ in range(6):
+        statuses.append(
+            client.post(
+                f"/locations/{lid}/regeocode",
+                headers=auth_headers(tenant_a, user_a),
+            ).status_code
+        )
+    # At least one of the 6 must be 429 — slowapi may permit fewer than the
+    # advertised count due to window boundaries.
+    assert 429 in statuses, f"expected a 429 in {statuses!r}"
+
+
+def test_post_location_unknown_customer_returns_404(client, tenant_a, user_a):
+    """Posting against a missing customer id returns 404."""
+    resp = client.post(
+        f"/customers/{uuid4()}/locations",
+        json={**_VALID_ADDR, "label": "x"},
+        headers=auth_headers(tenant_a, user_a),
+    )
+    assert resp.status_code == 404
+
+
+def test_get_location_cross_tenant_returns_404(
+    client, tenant_a, tenant_b, user_a
+):
+    """Reading a location from another tenant must return 404."""
+    cid = _create_customer(client, tenant_a, user_a)
+    create = client.post(
+        f"/customers/{cid}/locations",
+        json={**_VALID_ADDR, "label": "x"},
+        headers=auth_headers(tenant_a, user_a),
+    )
+    lid = create.json()["id"]
+
+    resp = client.get(
+        f"/locations/{lid}",
+        headers=auth_headers(tenant_b, user_a),
+    )
+    assert resp.status_code == 404
+
+
+def test_archive_location_admin_succeeds(client, tenant_a, user_a):
+    """Admins can archive a location."""
+    cid = _create_customer(client, tenant_a, user_a)
+    create = client.post(
+        f"/customers/{cid}/locations",
+        json={**_VALID_ADDR, "label": "x"},
+        headers=auth_headers(tenant_a, user_a),
+    )
+    lid = create.json()["id"]
+    resp = client.post(
+        f"/locations/{lid}/archive",
+        headers=auth_headers(tenant_a, user_a),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["archived"] is True

--- a/tests/api/test_locations_api.py
+++ b/tests/api/test_locations_api.py
@@ -15,7 +15,6 @@ from tests.api.conftest import (
     technician_headers,
 )
 
-
 _VALID_ADDR = {
     "street": "123 Main St",
     "city": "Philadelphia",
@@ -64,9 +63,7 @@ def test_post_location_geocode_failure_still_returns_201(client, tenant_a, user_
     assert resp.json()["geocode_status"] == "failed"
 
 
-def test_get_locations_for_customer_other_tenant_returns_404(
-    client, tenant_a, tenant_b, user_a
-):
+def test_get_locations_for_customer_other_tenant_returns_404(client, tenant_a, tenant_b, user_a):
     """Cross-tenant list returns 404 (silent RLS-style isolation)."""
     cid = _create_customer(client, tenant_a, user_a)
     resp = client.get(
@@ -139,9 +136,7 @@ def test_patch_location_address_triggers_regeocode(client, tenant_a, user_a):
     assert body1["lat"] != lat0
 
 
-def test_regeocode_endpoint_returns_200(
-    client, tenant_a, user_a, disabled_limiter
-):
+def test_regeocode_endpoint_returns_200(client, tenant_a, user_a, disabled_limiter):
     """Force-regeocode is exposed at POST /locations/{id}/regeocode.
 
     The endpoint carries a 5/minute rate limit (see slice design); the
@@ -204,9 +199,7 @@ def test_post_location_unknown_customer_returns_404(client, tenant_a, user_a):
     assert resp.status_code == 404
 
 
-def test_get_location_cross_tenant_returns_404(
-    client, tenant_a, tenant_b, user_a
-):
+def test_get_location_cross_tenant_returns_404(client, tenant_a, tenant_b, user_a):
     """Reading a location from another tenant must return 404."""
     cid = _create_customer(client, tenant_a, user_a)
     create = client.post(

--- a/tests/integration/test_customer_location_rls.py
+++ b/tests/integration/test_customer_location_rls.py
@@ -121,9 +121,7 @@ async def test_cascade_delete_locations_when_customer_hard_deleted(engine):
         )
         await session.commit()
 
-        await session.execute(
-            text("DELETE FROM customers WHERE id = :cid"), {"cid": str(cust)}
-        )
+        await session.execute(text("DELETE FROM customers WHERE id = :cid"), {"cid": str(cust)})
         await session.commit()
 
         remaining = (

--- a/tests/integration/test_customer_location_rls.py
+++ b/tests/integration/test_customer_location_rls.py
@@ -1,0 +1,135 @@
+"""Integration tests for Customer/Location tenant isolation via PostgreSQL RLS.
+
+These tests require a real PostgreSQL instance (Neon branch in CI) with the
+slice-9 migration applied. They are skipped automatically when ``DATABASE_URL``
+is not set so that the standard unit/API test run remains DB-free.
+
+Each test sets ``app.tenant_id`` via ``SET LOCAL`` (ADR 053) and asserts that
+RLS silently hides cross-tenant rows — the row appears not to exist rather
+than yielding a 403.
+"""
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+pytestmark = pytest.mark.integration
+
+
+_DATABASE_URL = os.environ.get("DATABASE_URL")
+
+
+@pytest.fixture()
+def database_url() -> str:
+    """Return DATABASE_URL or skip the test."""
+    if not _DATABASE_URL:
+        pytest.skip("DATABASE_URL not set — RLS integration tests skipped")
+    return _DATABASE_URL
+
+
+@pytest.fixture()
+async def engine(database_url):
+    """Async SQLAlchemy engine pointing at the test database."""
+    eng = create_async_engine(database_url, future=True)
+    yield eng
+    await eng.dispose()
+
+
+async def _set_tenant(session, tenant_id) -> None:
+    await session.execute(text(f"SET LOCAL app.tenant_id = '{tenant_id}'"))
+
+
+@pytest.mark.asyncio
+async def test_tenant_a_cannot_select_tenant_b_customer_via_rls(engine):
+    """Tenant A's session must not see Tenant B's customer rows.
+
+    Insert a customer as tenant B, then in a tenant-A session attempt to
+    SELECT that customer's id. Expect 0 rows (RLS silently hides the row).
+    """
+    tenant_a = uuid4()
+    tenant_b = uuid4()
+
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+
+    # Insert a tenant_b customer using a session scoped to tenant_b.
+    async with sessionmaker() as session:
+        await _set_tenant(session, tenant_b)
+        result = await session.execute(
+            text(
+                """
+                INSERT INTO customers (id, tenant_id, name, archived)
+                VALUES (gen_random_uuid(), :tenant_id, :name, false)
+                RETURNING id
+                """
+            ),
+            {"tenant_id": str(tenant_b), "name": "Tenant B Customer"},
+        )
+        tenant_b_customer_id = result.scalar_one()
+        await session.commit()
+
+    # Read in a tenant_a session — RLS should hide the row.
+    async with sessionmaker() as session:
+        await _set_tenant(session, tenant_a)
+        result = await session.execute(
+            text("SELECT id FROM customers WHERE id = :cid"),
+            {"cid": str(tenant_b_customer_id)},
+        )
+        rows = result.all()
+        assert rows == [], "RLS leak: tenant A can see tenant B's customer"
+
+
+@pytest.mark.asyncio
+async def test_cascade_delete_locations_when_customer_hard_deleted(engine):
+    """Hard-deleting a customer cascades to its locations (FK ON DELETE CASCADE)."""
+    tenant_id = uuid4()
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with sessionmaker() as session:
+        await _set_tenant(session, tenant_id)
+        cust = (
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO customers (id, tenant_id, name, archived)
+                    VALUES (gen_random_uuid(), :tenant_id, :name, false)
+                    RETURNING id
+                    """
+                ),
+                {"tenant_id": str(tenant_id), "name": "DeleteMe"},
+            )
+        ).scalar_one()
+        await session.execute(
+            text(
+                """
+                INSERT INTO locations (
+                    id, tenant_id, customer_id,
+                    street, city, state, postal_code, country,
+                    geocode_status, archived
+                ) VALUES (
+                    gen_random_uuid(), :tenant_id, :customer_id,
+                    '123 Main', 'Philadelphia', 'PA', '19103', 'US',
+                    'pending', false
+                )
+                """
+            ),
+            {"tenant_id": str(tenant_id), "customer_id": str(cust)},
+        )
+        await session.commit()
+
+        await session.execute(
+            text("DELETE FROM customers WHERE id = :cid"), {"cid": str(cust)}
+        )
+        await session.commit()
+
+        remaining = (
+            await session.execute(
+                text("SELECT count(*) FROM locations WHERE customer_id = :cid"),
+                {"cid": str(cust)},
+            )
+        ).scalar_one()
+        assert remaining == 0

--- a/tests/unit/test_customer_service.py
+++ b/tests/unit/test_customer_service.py
@@ -76,9 +76,7 @@ async def test_create_customer_emits_audit_event(service, audit, tenant_a, user_
     assert evt.details["customer_id"] == str(cust.id)
 
 
-async def test_update_customer_redacts_long_notes_in_audit(
-    service, audit, tenant_a, user_a
-):
+async def test_update_customer_redacts_long_notes_in_audit(service, audit, tenant_a, user_a):
     """Long ``notes`` fields are truncated in the audit details (ADR 063)."""
     cust = await service.create(tenant_id=tenant_a, user_id=user_a, name="Foo")
     long_notes = "x" * 500
@@ -96,9 +94,7 @@ async def test_update_customer_redacts_long_notes_in_audit(
     assert len(after["notes"]) < len(long_notes)
 
 
-async def test_archive_customer_sets_flag_and_audit(
-    service, audit, tenant_a, user_a
-):
+async def test_archive_customer_sets_flag_and_audit(service, audit, tenant_a, user_a):
     """Archive flips the flag, audit records the event."""
     cust = await service.create(tenant_id=tenant_a, user_id=user_a, name="Bar")
     archived = await service.archive(tenant_a, user_a, cust.id)
@@ -107,9 +103,7 @@ async def test_archive_customer_sets_flag_and_audit(
     assert any(e.event_type == "customer.archived" for e in audit.events)
 
 
-async def test_restore_customer_clears_flag_and_audit(
-    service, audit, tenant_a, user_a
-):
+async def test_restore_customer_clears_flag_and_audit(service, audit, tenant_a, user_a):
     """Restore unarchives and audits ``customer.restored``."""
     cust = await service.create(tenant_id=tenant_a, user_id=user_a, name="Baz")
     await service.archive(tenant_a, user_a, cust.id)
@@ -128,9 +122,7 @@ async def test_get_customer_cross_tenant_returns_not_found(
         await service.get(tenant_b, cust.id)
 
 
-async def test_list_customer_search_matches_name_substring(
-    service, tenant_a, user_a
-):
+async def test_list_customer_search_matches_name_substring(service, tenant_a, user_a):
     """``search`` filter uses substring matching on name (case-insensitive)."""
     await service.create(tenant_id=tenant_a, user_id=user_a, name="Acme Plumbing")
     await service.create(tenant_id=tenant_a, user_id=user_a, name="Beta HVAC")
@@ -142,9 +134,7 @@ async def test_list_customer_search_matches_name_substring(
     assert names == ["Acme Plumbing", "Acme Refrigeration"]
 
 
-async def test_list_customer_tenant_isolation(
-    service, tenant_a, tenant_b, user_a, user_b
-):
+async def test_list_customer_tenant_isolation(service, tenant_a, tenant_b, user_a, user_b):
     """``list`` only returns rows for the caller's tenant."""
     await service.create(tenant_id=tenant_a, user_id=user_a, name="A1")
     await service.create(tenant_id=tenant_a, user_id=user_a, name="A2")

--- a/tests/unit/test_customer_service.py
+++ b/tests/unit/test_customer_service.py
@@ -1,0 +1,164 @@
+"""Unit tests for :class:`CustomerService` (TDD-first, no DB).
+
+Audit redaction and tenant-defence are the security-critical behaviours; we
+test those explicitly. Cross-tenant reads must return ``CustomerNotFoundError``
+even when the caller knows the customer id (defence in depth on top of RLS).
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from office_hero.core.exceptions import CustomerNotFoundError
+from office_hero.repositories.customer_repository import (
+    InMemoryCustomerRepository,
+)
+from office_hero.repositories.mocks import InMemoryAuditService
+from office_hero.services.customer_service import CustomerService
+
+
+@pytest.fixture()
+def repo() -> InMemoryCustomerRepository:
+    """Fresh in-memory customer repository per test."""
+    return InMemoryCustomerRepository()
+
+
+@pytest.fixture()
+def audit() -> InMemoryAuditService:
+    """Fresh in-memory audit service per test."""
+    return InMemoryAuditService()
+
+
+@pytest.fixture()
+def service(repo: InMemoryCustomerRepository, audit: InMemoryAuditService) -> CustomerService:
+    """Service under test, wired to the in-memory deps."""
+    return CustomerService(repo=repo, audit=audit)
+
+
+@pytest.fixture()
+def tenant_a():
+    return uuid4()
+
+
+@pytest.fixture()
+def tenant_b():
+    return uuid4()
+
+
+@pytest.fixture()
+def user_a():
+    return uuid4()
+
+
+@pytest.fixture()
+def user_b():
+    return uuid4()
+
+
+async def test_create_customer_emits_audit_event(service, audit, tenant_a, user_a):
+    """Creating a customer must emit ``customer.created`` with the new id."""
+    cust = await service.create(
+        tenant_id=tenant_a,
+        user_id=user_a,
+        name="Acme Plumbing",
+        email="ops@acme.example",
+    )
+
+    assert cust.name == "Acme Plumbing"
+    assert cust.tenant_id == tenant_a
+    assert len(audit.events) == 1
+    evt = audit.events[0]
+    assert evt.event_type == "customer.created"
+    assert evt.tenant_id == tenant_a
+    assert evt.user_id == user_a
+    assert evt.details["customer_id"] == str(cust.id)
+
+
+async def test_update_customer_redacts_long_notes_in_audit(
+    service, audit, tenant_a, user_a
+):
+    """Long ``notes`` fields are truncated in the audit details (ADR 063)."""
+    cust = await service.create(tenant_id=tenant_a, user_id=user_a, name="Foo")
+    long_notes = "x" * 500
+    await service.update(
+        tenant_id=tenant_a,
+        user_id=user_a,
+        customer_id=cust.id,
+        patch={"notes": long_notes},
+    )
+
+    update_evt = next(e for e in audit.events if e.event_type == "customer.updated")
+    after = update_evt.details["after"]
+    assert "notes" in after
+    assert after["notes"].endswith("[truncated]")
+    assert len(after["notes"]) < len(long_notes)
+
+
+async def test_archive_customer_sets_flag_and_audit(
+    service, audit, tenant_a, user_a
+):
+    """Archive flips the flag, audit records the event."""
+    cust = await service.create(tenant_id=tenant_a, user_id=user_a, name="Bar")
+    archived = await service.archive(tenant_a, user_a, cust.id)
+
+    assert archived.archived is True
+    assert any(e.event_type == "customer.archived" for e in audit.events)
+
+
+async def test_restore_customer_clears_flag_and_audit(
+    service, audit, tenant_a, user_a
+):
+    """Restore unarchives and audits ``customer.restored``."""
+    cust = await service.create(tenant_id=tenant_a, user_id=user_a, name="Baz")
+    await service.archive(tenant_a, user_a, cust.id)
+    restored = await service.restore(tenant_a, user_a, cust.id)
+
+    assert restored.archived is False
+    assert any(e.event_type == "customer.restored" for e in audit.events)
+
+
+async def test_get_customer_cross_tenant_returns_not_found(
+    service, repo, tenant_a, tenant_b, user_a
+):
+    """Defence-in-depth: cross-tenant read MUST raise CustomerNotFoundError."""
+    cust = await service.create(tenant_id=tenant_a, user_id=user_a, name="Tenant A Co")
+    with pytest.raises(CustomerNotFoundError):
+        await service.get(tenant_b, cust.id)
+
+
+async def test_list_customer_search_matches_name_substring(
+    service, tenant_a, user_a
+):
+    """``search`` filter uses substring matching on name (case-insensitive)."""
+    await service.create(tenant_id=tenant_a, user_id=user_a, name="Acme Plumbing")
+    await service.create(tenant_id=tenant_a, user_id=user_a, name="Beta HVAC")
+    await service.create(tenant_id=tenant_a, user_id=user_a, name="Acme Refrigeration")
+
+    rows, total = await service.list(tenant_a, search="acme")
+    assert total == 2
+    names = sorted(r.name for r in rows)
+    assert names == ["Acme Plumbing", "Acme Refrigeration"]
+
+
+async def test_list_customer_tenant_isolation(
+    service, tenant_a, tenant_b, user_a, user_b
+):
+    """``list`` only returns rows for the caller's tenant."""
+    await service.create(tenant_id=tenant_a, user_id=user_a, name="A1")
+    await service.create(tenant_id=tenant_a, user_id=user_a, name="A2")
+    await service.create(tenant_id=tenant_b, user_id=user_b, name="B1")
+
+    rows_a, total_a = await service.list(tenant_a)
+    rows_b, total_b = await service.list(tenant_b)
+    assert total_a == 2
+    assert total_b == 1
+    assert {r.name for r in rows_a} == {"A1", "A2"}
+    assert {r.name for r in rows_b} == {"B1"}
+
+
+async def test_update_unknown_customer_raises(service, tenant_a, user_a):
+    """Updating a missing id surfaces :class:`CustomerNotFoundError`."""
+    with pytest.raises(CustomerNotFoundError):
+        await service.update(tenant_a, user_a, uuid4(), {"name": "ghost"})

--- a/tests/unit/test_location_service.py
+++ b/tests/unit/test_location_service.py
@@ -1,0 +1,281 @@
+"""Unit tests for :class:`LocationService` (TDD-first, no DB or live network)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from office_hero.adapters.geocoding.protocol import (
+    AddressInput,
+    Coordinates,
+    GeocodingAdapter,
+)
+from office_hero.adapters.geocoding.stub import StubGeocodingAdapter
+from office_hero.core.exceptions import (
+    CustomerNotFoundError,
+    GeocodingError,
+)
+from office_hero.repositories.customer_repository import (
+    InMemoryCustomerRepository,
+)
+from office_hero.repositories.location_repository import (
+    InMemoryLocationRepository,
+)
+from office_hero.repositories.mocks import InMemoryAuditService
+from office_hero.services.location_service import LocationService
+
+
+class _FailingGeocoder(GeocodingAdapter):
+    """Geocoder that always raises :class:`GeocodingError` — for tests."""
+
+    async def geocode(self, address: AddressInput) -> Coordinates | None:
+        raise GeocodingError("simulated network error")
+
+
+class _MissGeocoder(GeocodingAdapter):
+    """Geocoder that always returns ``None`` (no match found)."""
+
+    async def geocode(self, address: AddressInput) -> Coordinates | None:
+        return None
+
+
+@pytest.fixture()
+def cust_repo() -> InMemoryCustomerRepository:
+    return InMemoryCustomerRepository()
+
+
+@pytest.fixture()
+def loc_repo() -> InMemoryLocationRepository:
+    return InMemoryLocationRepository()
+
+
+@pytest.fixture()
+def audit() -> InMemoryAuditService:
+    return InMemoryAuditService()
+
+
+@pytest.fixture()
+def stub_geocoder() -> StubGeocodingAdapter:
+    return StubGeocodingAdapter()
+
+
+@pytest.fixture()
+def service(
+    loc_repo, cust_repo, audit, stub_geocoder
+) -> LocationService:
+    return LocationService(
+        repo=loc_repo,
+        customer_repo=cust_repo,
+        audit=audit,
+        geocoder=stub_geocoder,
+    )
+
+
+@pytest.fixture()
+def tenant_a():
+    return uuid4()
+
+
+@pytest.fixture()
+def tenant_b():
+    return uuid4()
+
+
+@pytest.fixture()
+def user_a():
+    return uuid4()
+
+
+_VALID_ADDRESS = {
+    "street": "123 Main St",
+    "city": "Philadelphia",
+    "state": "PA",
+    "postal_code": "19103",
+    "country": "US",
+}
+
+
+async def test_create_location_calls_geocoder_and_sets_coordinates(
+    service, cust_repo, audit, tenant_a, user_a
+):
+    """``create`` geocodes the address and persists lat/lng + status=ok."""
+    cust = await cust_repo.create(tenant_a, name="Acme Plumbing")
+    loc = await service.create(
+        tenant_id=tenant_a,
+        user_id=user_a,
+        customer_id=cust.id,
+        address_fields=dict(_VALID_ADDRESS),
+        label="Main Office",
+    )
+
+    assert loc.lat is not None and loc.lng is not None
+    assert loc.geocode_status == "ok"
+    assert loc.geocode_source == "stub"
+    assert any(e.event_type == "location.created" for e in audit.events)
+
+
+async def test_create_location_geocoder_failure_marks_failed_but_returns_location(
+    loc_repo, cust_repo, audit, tenant_a, user_a
+):
+    """When the geocoder raises we still return the location with status=failed."""
+    svc = LocationService(
+        repo=loc_repo,
+        customer_repo=cust_repo,
+        audit=audit,
+        geocoder=_FailingGeocoder(),
+    )
+    cust = await cust_repo.create(tenant_a, name="Acme")
+    loc = await svc.create(
+        tenant_id=tenant_a,
+        user_id=user_a,
+        customer_id=cust.id,
+        address_fields=dict(_VALID_ADDRESS),
+        label="x",
+    )
+
+    assert loc.geocode_status == "failed"
+    assert loc.lat is None
+    assert any(e.event_type == "location.created" for e in audit.events)
+
+
+async def test_create_location_geocoder_miss_marks_failed(
+    loc_repo, cust_repo, audit, tenant_a, user_a
+):
+    """Geocoder returning ``None`` also flips status to ``failed``."""
+    svc = LocationService(
+        repo=loc_repo,
+        customer_repo=cust_repo,
+        audit=audit,
+        geocoder=_MissGeocoder(),
+    )
+    cust = await cust_repo.create(tenant_a, name="Acme")
+    loc = await svc.create(
+        tenant_id=tenant_a,
+        user_id=user_a,
+        customer_id=cust.id,
+        address_fields=dict(_VALID_ADDRESS),
+        label="x",
+    )
+
+    assert loc.geocode_status == "failed"
+
+
+async def test_create_location_geocode_false_skips_geocoder(
+    service, cust_repo, tenant_a, user_a
+):
+    """``geocode=False`` leaves the location in ``pending``."""
+    cust = await cust_repo.create(tenant_a, name="Acme")
+    loc = await service.create(
+        tenant_id=tenant_a,
+        user_id=user_a,
+        customer_id=cust.id,
+        address_fields=dict(_VALID_ADDRESS),
+        label="x",
+        geocode=False,
+    )
+    assert loc.geocode_status == "pending"
+    assert loc.lat is None
+
+
+async def test_update_location_address_auto_regeocodes(
+    service, cust_repo, tenant_a, user_a
+):
+    """Changing an address field re-geocodes by default (``auto``)."""
+    cust = await cust_repo.create(tenant_a, name="Acme")
+    loc = await service.create(
+        tenant_id=tenant_a,
+        user_id=user_a,
+        customer_id=cust.id,
+        address_fields=dict(_VALID_ADDRESS),
+        label="x",
+    )
+    first_lat = loc.lat
+
+    updated = await service.update(
+        tenant_id=tenant_a,
+        user_id=user_a,
+        location_id=loc.id,
+        patch={"street": "456 Different Ave"},
+    )
+    assert updated.geocode_status == "ok"
+    # Stub coordinates are deterministic on street; they must differ.
+    assert updated.lat != first_lat
+
+
+async def test_update_location_label_only_does_not_regeocode(
+    service, cust_repo, audit, tenant_a, user_a
+):
+    """Label-only updates don't trigger a re-geocode."""
+    cust = await cust_repo.create(tenant_a, name="Acme")
+    loc = await service.create(
+        tenant_id=tenant_a,
+        user_id=user_a,
+        customer_id=cust.id,
+        address_fields=dict(_VALID_ADDRESS),
+        label="Old",
+    )
+
+    updated = await service.update(
+        tenant_id=tenant_a,
+        user_id=user_a,
+        location_id=loc.id,
+        patch={"label": "New"},
+    )
+    update_evt = next(e for e in audit.events if e.event_type == "location.updated")
+    assert update_evt.details["regeocoded"] is False
+    assert updated.label == "New"
+
+
+async def test_manual_set_coordinates_overrides_geocoder_status(
+    service, cust_repo, audit, tenant_a, user_a
+):
+    """Manual coordinate override sets status/source to ``manual``."""
+    cust = await cust_repo.create(tenant_a, name="Acme")
+    loc = await service.create(
+        tenant_id=tenant_a,
+        user_id=user_a,
+        customer_id=cust.id,
+        address_fields=dict(_VALID_ADDRESS),
+        label="x",
+    )
+
+    updated = await service.manual_set_coordinates(
+        tenant_id=tenant_a,
+        user_id=user_a,
+        location_id=loc.id,
+        lat=39.951,
+        lng=-75.165,
+    )
+    assert updated.geocode_status == "manual"
+    assert updated.geocode_source == "manual"
+    assert any(
+        e.event_type == "location.coordinates_set_manual" for e in audit.events
+    )
+
+
+async def test_create_location_other_tenant_customer_raises_not_found(
+    service, cust_repo, tenant_a, tenant_b, user_a
+):
+    """Creating a location for a foreign-tenant customer raises CustomerNotFoundError."""
+    cust = await cust_repo.create(tenant_a, name="Tenant A Co")
+    with pytest.raises(CustomerNotFoundError):
+        await service.create(
+            tenant_id=tenant_b,
+            user_id=user_a,
+            customer_id=cust.id,
+            address_fields=dict(_VALID_ADDRESS),
+            label="x",
+        )
+
+
+async def test_create_location_unknown_customer_raises(service, tenant_a, user_a):
+    """Unknown customer id surfaces :class:`CustomerNotFoundError`."""
+    with pytest.raises(CustomerNotFoundError):
+        await service.create(
+            tenant_id=tenant_a,
+            user_id=user_a,
+            customer_id=uuid4(),
+            address_fields=dict(_VALID_ADDRESS),
+            label="x",
+        )

--- a/tests/unit/test_location_service.py
+++ b/tests/unit/test_location_service.py
@@ -61,9 +61,7 @@ def stub_geocoder() -> StubGeocodingAdapter:
 
 
 @pytest.fixture()
-def service(
-    loc_repo, cust_repo, audit, stub_geocoder
-) -> LocationService:
+def service(loc_repo, cust_repo, audit, stub_geocoder) -> LocationService:
     return LocationService(
         repo=loc_repo,
         customer_repo=cust_repo,
@@ -161,9 +159,7 @@ async def test_create_location_geocoder_miss_marks_failed(
     assert loc.geocode_status == "failed"
 
 
-async def test_create_location_geocode_false_skips_geocoder(
-    service, cust_repo, tenant_a, user_a
-):
+async def test_create_location_geocode_false_skips_geocoder(service, cust_repo, tenant_a, user_a):
     """``geocode=False`` leaves the location in ``pending``."""
     cust = await cust_repo.create(tenant_a, name="Acme")
     loc = await service.create(
@@ -178,9 +174,7 @@ async def test_create_location_geocode_false_skips_geocoder(
     assert loc.lat is None
 
 
-async def test_update_location_address_auto_regeocodes(
-    service, cust_repo, tenant_a, user_a
-):
+async def test_update_location_address_auto_regeocodes(service, cust_repo, tenant_a, user_a):
     """Changing an address field re-geocodes by default (``auto``)."""
     cust = await cust_repo.create(tenant_a, name="Acme")
     loc = await service.create(
@@ -249,9 +243,7 @@ async def test_manual_set_coordinates_overrides_geocoder_status(
     )
     assert updated.geocode_status == "manual"
     assert updated.geocode_source == "manual"
-    assert any(
-        e.event_type == "location.coordinates_set_manual" for e in audit.events
-    )
+    assert any(e.event_type == "location.coordinates_set_manual" for e in audit.events)
 
 
 async def test_create_location_other_tenant_customer_raises_not_found(

--- a/tests/unit/test_nominatim_adapter.py
+++ b/tests/unit/test_nominatim_adapter.py
@@ -1,0 +1,161 @@
+"""Unit tests for :class:`NominatimGeocodingAdapter`.
+
+Network calls are stubbed via ``httpx.MockTransport`` so the tests never hit
+the real Nominatim service (Nominatim ToS would not be happy with a CI run
+spamming them).
+"""
+
+from __future__ import annotations
+
+import time
+
+import httpx
+import pytest
+
+from office_hero.adapters.geocoding.nominatim import NominatimGeocodingAdapter
+from office_hero.adapters.geocoding.protocol import AddressInput
+from office_hero.core.exceptions import GeocodingError
+
+
+_ALLOWLIST = ["nominatim.openstreetmap.org"]
+_BASE_URL = "https://nominatim.openstreetmap.org"
+_USER_AGENT = "office-hero/test (contact@example.com)"
+
+
+def _make_adapter(handler, *, timeout: float = 5.0) -> NominatimGeocodingAdapter:
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport, timeout=timeout)
+    return NominatimGeocodingAdapter(
+        base_url=_BASE_URL,
+        user_agent=_USER_AGENT,
+        timeout=timeout,
+        allowlist=_ALLOWLIST,
+        client=client,
+    )
+
+
+def _hit(payload):
+    """Handler factory returning a 200 with ``payload`` for every call."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=payload, request=request)
+
+    return handler
+
+
+async def test_nominatim_returns_coordinates_on_match():
+    """A 200 with a non-empty body yields parsed Coordinates."""
+    payload = [{"lat": "39.9526", "lon": "-75.1652", "display_name": "Philly"}]
+    adapter = _make_adapter(_hit(payload))
+
+    coords = await adapter.geocode(
+        AddressInput(
+            street="123 Main St",
+            city="Philadelphia",
+            state="PA",
+            postal_code="19103",
+            country="US",
+        )
+    )
+    assert coords is not None
+    assert coords.lat == pytest.approx(39.9526)
+    assert coords.lng == pytest.approx(-75.1652)
+    assert coords.source == "nominatim"
+
+
+async def test_nominatim_returns_none_on_no_match():
+    """Empty list -> ``None``."""
+    adapter = _make_adapter(_hit([]))
+    coords = await adapter.geocode(
+        AddressInput(
+            street="nowhere",
+            city="??",
+            state="??",
+            postal_code="00000",
+            country="US",
+        )
+    )
+    assert coords is None
+
+
+async def test_nominatim_rate_limit_one_per_second():
+    """Second consecutive call must wait >= ~1s (Nominatim ToS)."""
+    payload = [{"lat": "0", "lon": "0", "display_name": "x"}]
+    adapter = _make_adapter(_hit(payload))
+    addr = AddressInput(street="a", city="b", state="c", postal_code="d", country="US")
+
+    await adapter.geocode(addr)
+    t0 = time.monotonic()
+    await adapter.geocode(addr)
+    elapsed = time.monotonic() - t0
+    # Allow a small slack window — the gate is precisely ``>= 1.0``.
+    assert elapsed >= 0.95
+
+
+async def test_nominatim_rejects_host_outside_allowlist():
+    """Constructing the adapter with an off-allowlist host raises GeocodingError."""
+    with pytest.raises(GeocodingError):
+        NominatimGeocodingAdapter(
+            base_url="https://evil.example.com",
+            user_agent=_USER_AGENT,
+            timeout=5.0,
+            allowlist=_ALLOWLIST,
+        )
+
+
+async def test_nominatim_timeout_raises_geocoding_error():
+    """``httpx.TimeoutException`` is translated to GeocodingError."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.TimeoutException("simulated timeout")
+
+    adapter = _make_adapter(handler)
+    with pytest.raises(GeocodingError):
+        await adapter.geocode(
+            AddressInput(
+                street="a", city="b", state="c", postal_code="d", country="US"
+            )
+        )
+
+
+async def test_nominatim_sends_user_agent_header():
+    """The configured ``User-Agent`` must be sent on every request."""
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["ua"] = request.headers.get("user-agent")
+        return httpx.Response(
+            200,
+            json=[{"lat": "0", "lon": "0", "display_name": "x"}],
+            request=request,
+        )
+
+    adapter = _make_adapter(handler)
+    await adapter.geocode(
+        AddressInput(street="a", city="b", state="c", postal_code="d", country="US")
+    )
+    assert captured["ua"] == _USER_AGENT
+
+
+async def test_nominatim_bad_status_raises():
+    """Non-200 status results in :class:`GeocodingError`."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"error": "down"}, request=request)
+
+    adapter = _make_adapter(handler)
+    with pytest.raises(GeocodingError):
+        await adapter.geocode(
+            AddressInput(street="a", city="b", state="c", postal_code="d", country="US")
+        )
+
+
+async def test_nominatim_missing_user_agent_raises():
+    """Empty user_agent is rejected at construction."""
+    with pytest.raises(GeocodingError):
+        NominatimGeocodingAdapter(
+            base_url=_BASE_URL,
+            user_agent="",
+            timeout=1.0,
+            allowlist=_ALLOWLIST,
+        )

--- a/tests/unit/test_nominatim_adapter.py
+++ b/tests/unit/test_nominatim_adapter.py
@@ -16,7 +16,6 @@ from office_hero.adapters.geocoding.nominatim import NominatimGeocodingAdapter
 from office_hero.adapters.geocoding.protocol import AddressInput
 from office_hero.core.exceptions import GeocodingError
 
-
 _ALLOWLIST = ["nominatim.openstreetmap.org"]
 _BASE_URL = "https://nominatim.openstreetmap.org"
 _USER_AGENT = "office-hero/test (contact@example.com)"
@@ -112,9 +111,7 @@ async def test_nominatim_timeout_raises_geocoding_error():
     adapter = _make_adapter(handler)
     with pytest.raises(GeocodingError):
         await adapter.geocode(
-            AddressInput(
-                street="a", city="b", state="c", postal_code="d", country="US"
-            )
+            AddressInput(street="a", city="b", state="c", postal_code="d", country="US")
         )
 
 


### PR DESCRIPTION
## Summary

Implements **Slice 9 (Customer & Location management)** per the design doc at
`project-documents/user/slices/011-slice.customer-location.md`.

This is the first core FSM feature slice: CRUD for `Customer` and `Location`
aggregates with a 1:N relationship, a pluggable `GeocodingAdapter` family
(default = Nominatim, ORS stubbed for follow-up), tenant isolation via
PostgreSQL RLS (ADR 053), RBAC via `@require_permission` / `@require_role`
(ADR 060), and audit-event emission on state changes (ADR 063).

## What landed

Four commits, scoped at the design-doc boundaries:

1. **`feat(slice-9): GeocodingAdapter protocol + NominatimAdapter`** —
   adapter protocol, Nominatim impl (1 req/sec semaphore + SSRF allowlist),
   stub, ORS skeleton, factory; `Settings` extended; new exceptions.
2. **`feat(slice-9): Customer/Location models + migration`** — SQLAlchemy 2.x
   models + Alembic `0004_customers_and_locations.py` with RLS, partial-unique
   email index, GIN trigram index for name search, ON DELETE CASCADE.
3. **`feat(slice-9): repositories + service + audit events`** — repository
   protocols + concrete + in-memory mocks, `CustomerService` /
   `LocationService` with audit emission and PII redaction in audit details.
4. **`feat(slice-9): API routes + RBAC + tests`** — Pydantic v2 schemas,
   FastAPI routers, RBAC decorators, rate limits (60/min write, 5/min
   regeocode), full API + integration test surface.

## ADR alignment

- **ADR 053** Tenant isolation (RLS) — both new tables get `ENABLE ROW LEVEL SECURITY` + a `tenant_id = current_setting('app.tenant_id')::uuid` policy in the migration; the service layer also re-checks tenant on every read/write (defence in depth).
- **ADR 058** SQLAlchemy 2.x + Repository pattern — services depend on `*RepositoryProtocol` ABCs; concrete impls and in-memory mocks both honour them.
- **ADR 059** PostgreSQL JSONB / CITEXT / pg_trgm — extensions enabled in migration (`CREATE EXTENSION IF NOT EXISTS`); email uniqueness uses `lower(email)` functional index for case-insensitivity (chose this over CITEXT column for swap-cost reasons).
- **ADR 060** Auth/RBAC — `customers:read` / `customers:write` permissions on read/write verbs; admin-only verbs (archive/restore/coordinates) restricted via `@require_role`.
- **ADR 062** Rate limiting — `POST /customers` and `POST /customers/{cid}/locations` at 60/min (write tier); `POST /locations/{id}/regeocode` at 5/min to protect the Nominatim quota.
- **ADR 063** Audit + structured logging — every state change emits via the `AuditService` contract; long free-text `notes` truncated at 256 chars before persistence.

## Open design questions

The design doc's Risk Callouts section called out a few "OPEN QUESTIONS"
the implementation had to resolve. Resolutions:

- **Email uniqueness scoping.** Kept the partial-unique index per the spec
  (`(tenant_id, lower(email)) WHERE email IS NOT NULL AND archived = false`).
  This is the conservative default; if real-world data hits the shared-email
  case (e.g. spouses on one billing address) we can drop the index in a
  follow-up migration.
- **Regeocode rate limit.** Implemented 5/minute per the spec; this is per-IP
  (slowapi default key). A follow-up will likely want per-tenant.
- **PII in audit log.** `notes` fields > 256 chars are truncated with a
  `...[truncated]` suffix in the audit `details.before` / `details.after`
  diffs. Implemented in `CustomerService._redact_notes`.

No new ADR-level decisions required.

## CI

- `poetry run pytest -q` — 197 passed, 9 skipped (2 of which are this
  slice's RLS integration tests that auto-skip without `DATABASE_URL`),
  1 pre-existing failure in `tests/test_service_startup.py` that is an
  environmental issue with subprocess `PYTHONPATH` for the `mcp` module
  (not touched by this PR).
- `poetry run pre-commit run --all-files` — all hooks pass
  (black, ruff, markdownlint, mixed-line-ending, etc.).
- `python3 -c "from office_hero.api.app import app"` — clean import, 27 routes.

## Test plan

- [x] Unit tests: `pytest tests/unit/ -q` (25 passing)
- [x] API tests: `pytest tests/api/ -q` (21 passing)
- [x] App boot: `python3 -c "from office_hero.api.app import app"` succeeds
- [x] Pre-commit: `poetry run pre-commit run --all-files` clean
- [ ] Integration RLS: requires a Neon branch; run with `DATABASE_URL` set
- [ ] Alembic up/down round-trip against a Neon branch
- [ ] Live Nominatim smoke (manual, off CI — see `geocoding_adapter=nominatim`)

## Notes for the reviewer

- This worktree was shared with a concurrent agent working on the design
  system bootstrap (`feat/design-system-bootstrap`). I stashed/separated
  their tracked changes before staging my own commits to keep the diff
  clean; a manual `git diff main..feat/slice-9-customer-location` should
  show only slice-9 paths.
- The `.claude/scope` file in this worktree is session-local
  (gitignored by convention) and is not part of the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)