### PR TITLE
feat(slice-10): Jobs admin UI — table, status badges, create modal

### DIFF
--- a/apps/admin-web/src/__tests__/JobsPage.test.tsx
+++ b/apps/admin-web/src/__tests__/JobsPage.test.tsx
@@ -1,45 +1,47 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
-const mockListDeadLetters = jest.fn();
-const mockRetryDeadLetter = jest.fn();
+const mockListJobsApi = jest.fn();
+const mockCreateJobApi = jest.fn();
 
 jest.mock('../api', () => ({
-  listDeadLetters: (...args: unknown[]) => mockListDeadLetters(...args),
-  retryDeadLetter: (...args: unknown[]) => mockRetryDeadLetter(...args),
+  listJobsApi: (...args: unknown[]) => mockListJobsApi(...args),
+  createJobApi: (...args: unknown[]) => mockCreateJobApi(...args),
 }));
 
 import { JobsPage } from '../pages/JobsPage';
 
-const buildItem = (overrides: Record<string, unknown> = {}) => ({
-  id: 'evt-1',
-  tenant_id: 'tenant-1',
-  event_type: 'dispatch_job',
-  payload: {},
-  status: 'dead',
-  attempt_count: 3,
-  created_at: null,
-  processed_at: null,
-  dead_letter_reason: 'max retries exceeded',
+const buildJob = (overrides: Record<string, unknown> = {}) => ({
+  id: 'job-1',
+  title: 'Fix leaking pipe',
+  status: 'pending',
+  priority: 50,
+  scheduled_for: null,
+  customer_id: 'cust-1',
+  location_id: 'loc-1',
+  industry: 'plumbing',
+  service_type: 'Drain cleaning',
   ...overrides,
 });
 
-describe('JobsPage (dead-letter)', () => {
+const emptyResponse = { items: [], total: 0, limit: 50, offset: 0 };
+
+describe('JobsPage', () => {
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
-  it('shows loading state initially', () => {
-    mockListDeadLetters.mockReturnValue(new Promise(() => {}));
+  it('shows loading skeletons initially', () => {
+    mockListJobsApi.mockReturnValue(new Promise(() => {}));
     render(<JobsPage />);
-    expect(screen.getByText('Loading dead-letter events…')).toBeInTheDocument();
+    expect(document.querySelectorAll('[class*="animate-pulse"]').length).toBeGreaterThan(0);
   });
 
-  it('renders dead-letter events in a table on success', async () => {
-    mockListDeadLetters.mockResolvedValue({
+  it('renders job rows on success', async () => {
+    mockListJobsApi.mockResolvedValue({
       items: [
-        buildItem({ id: 'evt-1', event_type: 'dispatch_job' }),
-        buildItem({ id: 'evt-2', event_type: 'sync_customer', attempt_count: 5 }),
+        buildJob({ id: 'job-1', title: 'Fix leaking pipe' }),
+        buildJob({ id: 'job-2', title: 'Replace boiler', status: 'scheduled' }),
       ],
       total: 2,
       limit: 50,
@@ -49,70 +51,93 @@ describe('JobsPage (dead-letter)', () => {
     render(<JobsPage />);
 
     await waitFor(() => {
-      const rows = screen.getAllByTestId('dead-letter-row');
-      expect(rows).toHaveLength(2);
+      expect(screen.getAllByTestId('job-row')).toHaveLength(2);
     });
 
-    expect(screen.getByText('evt-1')).toBeInTheDocument();
-    expect(screen.getByText('evt-2')).toBeInTheDocument();
-    expect(screen.getByText('dispatch_job')).toBeInTheDocument();
-    expect(screen.getByText('sync_customer')).toBeInTheDocument();
+    expect(screen.getByText('Fix leaking pipe')).toBeInTheDocument();
+    expect(screen.getByText('Replace boiler')).toBeInTheDocument();
+    expect(screen.getAllByText('Pending').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Scheduled').length).toBeGreaterThan(0);
   });
 
-  it('shows an empty message when no dead-letter events exist', async () => {
-    mockListDeadLetters.mockResolvedValue({ items: [], total: 0, limit: 50, offset: 0 });
+  it('shows empty state when no jobs', async () => {
+    mockListJobsApi.mockResolvedValue(emptyResponse);
 
     render(<JobsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText(/No dead-letter events/i)).toBeInTheDocument();
+      expect(screen.getByText(/No jobs found/i)).toBeInTheDocument();
     });
   });
 
-  it('retries a dead-letter and refreshes the list', async () => {
-    mockListDeadLetters
-      .mockResolvedValueOnce({ items: [buildItem()], total: 1, limit: 50, offset: 0 })
-      .mockResolvedValueOnce({ items: [], total: 0, limit: 50, offset: 0 });
-    mockRetryDeadLetter.mockResolvedValue({ id: 'evt-1', status: 'pending', message: 'ok' });
-
-    render(<JobsPage />);
-
-    const retryBtn = await screen.findByRole('button', { name: /Retry/i });
-    fireEvent.click(retryBtn);
-
-    await waitFor(() => {
-      expect(mockRetryDeadLetter).toHaveBeenCalledWith('evt-1');
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText(/No dead-letter events/i)).toBeInTheDocument();
-    });
-  });
-
-  it('shows an error when listDeadLetters fails', async () => {
-    mockListDeadLetters.mockRejectedValue({ status: 500, detail: 'boom' });
+  it('shows error alert on load failure', async () => {
+    mockListJobsApi.mockRejectedValue({ status: 500, detail: 'server exploded' });
 
     render(<JobsPage />);
 
     const alert = await screen.findByRole('alert');
-    expect(alert).toHaveTextContent('boom');
+    expect(alert).toHaveTextContent('server exploded');
   });
 
-  it('shows an error when retry fails', async () => {
-    mockListDeadLetters.mockResolvedValue({
-      items: [buildItem()],
-      total: 1,
-      limit: 50,
-      offset: 0,
-    });
-    mockRetryDeadLetter.mockRejectedValue({ status: 400, detail: 'cannot retry' });
-
+  it('opens create modal when New job button clicked', async () => {
+    mockListJobsApi.mockResolvedValue(emptyResponse);
     render(<JobsPage />);
 
-    const retryBtn = await screen.findByRole('button', { name: /Retry/i });
-    fireEvent.click(retryBtn);
+    await waitFor(() => screen.getByText(/No jobs found/i));
 
-    const alert = await screen.findByRole('alert');
-    expect(alert).toHaveTextContent('cannot retry');
+    fireEvent.click(screen.getByRole('button', { name: /New job/i }));
+    expect(screen.getByText('New Job')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Title/i)).toBeInTheDocument();
+  });
+
+  it('creates a job and adds it to the list', async () => {
+    mockListJobsApi.mockResolvedValue(emptyResponse);
+    const newJob = buildJob({ id: 'job-new', title: 'Emergency call' });
+    mockCreateJobApi.mockResolvedValue(newJob);
+
+    render(<JobsPage />);
+    await waitFor(() => screen.getByText(/No jobs found/i));
+
+    fireEvent.click(screen.getByRole('button', { name: /New job/i }));
+
+    fireEvent.change(screen.getByLabelText(/Title/i), {
+      target: { value: 'Emergency call' },
+    });
+    fireEvent.change(screen.getAllByPlaceholderText('UUID')[0], {
+      target: { value: 'cust-1' },
+    });
+    fireEvent.change(screen.getAllByPlaceholderText('UUID')[1], {
+      target: { value: 'loc-1' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Create job/i }));
+
+    await waitFor(() => {
+      expect(mockCreateJobApi).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Emergency call', customer_id: 'cust-1' })
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Emergency call')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error in modal on create failure', async () => {
+    mockListJobsApi.mockResolvedValue(emptyResponse);
+    mockCreateJobApi.mockRejectedValue({ status: 422, detail: 'invalid customer' });
+
+    render(<JobsPage />);
+    await waitFor(() => screen.getByText(/No jobs found/i));
+
+    fireEvent.click(screen.getByRole('button', { name: /New job/i }));
+    fireEvent.change(screen.getByLabelText(/Title/i), { target: { value: 'Test' } });
+    fireEvent.change(screen.getAllByPlaceholderText('UUID')[0], { target: { value: 'cust-x' } });
+    fireEvent.change(screen.getAllByPlaceholderText('UUID')[1], { target: { value: 'loc-x' } });
+    fireEvent.click(screen.getByRole('button', { name: /Create job/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('invalid customer')).toBeInTheDocument();
+    });
   });
 });

--- a/apps/admin-web/src/api.ts
+++ b/apps/admin-web/src/api.ts
@@ -151,3 +151,62 @@ export function getSagaLogs(sagaId: string): Promise<SagaState> {
 export function healthCheck(): Promise<{ status: string }> {
   return request<{ status: string }>('/health');
 }
+
+// --- Job types (Slice 10) ---
+
+export type JobStatus = 'pending' | 'scheduled' | 'in_progress' | 'completed' | 'cancelled';
+
+export interface JobSummary {
+  id: string;
+  title: string;
+  status: JobStatus;
+  priority: number;
+  scheduled_for: string | null;
+  customer_id: string;
+  location_id: string;
+  industry: string;
+  service_type: string | null;
+}
+
+export interface JobListResponse {
+  items: JobSummary[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface JobCreate {
+  customer_id: string;
+  location_id: string;
+  title: string;
+  description?: string | null;
+  priority?: number;
+  service_type?: string | null;
+  estimated_duration_min?: number;
+}
+
+// --- Job API functions ---
+
+export interface JobListParams {
+  status?: JobStatus;
+  search?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export function listJobsApi(params: JobListParams = {}): Promise<JobListResponse> {
+  const qs = new URLSearchParams();
+  if (params.status) qs.set('status', params.status);
+  if (params.search) qs.set('search', params.search);
+  if (params.limit != null) qs.set('limit', String(params.limit));
+  if (params.offset != null) qs.set('offset', String(params.offset));
+  const query = qs.toString() ? `?${qs.toString()}` : '';
+  return request<JobListResponse>(`/jobs${query}`);
+}
+
+export function createJobApi(body: JobCreate): Promise<JobSummary> {
+  return request<JobSummary>('/jobs', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}

--- a/apps/admin-web/src/pages/JobsPage.tsx
+++ b/apps/admin-web/src/pages/JobsPage.tsx
@@ -1,136 +1,307 @@
-/**
- * JobsPage — dead-letter outbox events with retry action.
- *
- * Lists failed outbox events from GET /admin/dead-letters and lets an
- * Operator re-queue any of them via POST /admin/dead-letters/{id}/retry.
- * After a successful retry the list refreshes so the event disappears.
- */
-
 import React, { useCallback, useEffect, useState } from 'react';
 import {
   type ApiError,
-  type DeadLetterItem,
-  listDeadLetters,
-  retryDeadLetter,
+  type JobCreate,
+  type JobListParams,
+  type JobStatus,
+  type JobSummary,
+  createJobApi,
+  listJobsApi,
 } from '../api';
+import { Alert } from '../components/ui/Alert';
+import { Button } from '../components/ui/Button';
+import { Input } from '../components/ui/Input';
+import { Skeleton } from '../components/ui/Skeleton';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../components/ui/Table';
+
+const STATUS_COLORS: Record<JobStatus, string> = {
+  pending:     'bg-amber-100 text-amber-800',
+  scheduled:   'bg-blue-100 text-blue-800',
+  in_progress: 'bg-indigo-100 text-indigo-800',
+  completed:   'bg-green-100 text-green-800',
+  cancelled:   'bg-neutral-100 text-neutral-500',
+};
+
+const STATUS_LABELS: Record<JobStatus, string> = {
+  pending:     'Pending',
+  scheduled:   'Scheduled',
+  in_progress: 'In Progress',
+  completed:   'Completed',
+  cancelled:   'Cancelled',
+};
+
+function StatusBadge({ status }: { status: JobStatus }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${STATUS_COLORS[status] ?? 'bg-neutral-100 text-neutral-600'}`}
+    >
+      {STATUS_LABELS[status] ?? status}
+    </span>
+  );
+}
+
+const STATUS_FILTER_OPTIONS: Array<{ value: JobStatus | ''; label: string }> = [
+  { value: '',            label: 'All statuses' },
+  { value: 'pending',     label: 'Pending' },
+  { value: 'scheduled',   label: 'Scheduled' },
+  { value: 'in_progress', label: 'In Progress' },
+  { value: 'completed',   label: 'Completed' },
+  { value: 'cancelled',   label: 'Cancelled' },
+];
+
+function CreateJobModal({
+  onClose,
+  onCreated,
+}: {
+  onClose: () => void;
+  onCreated: (job: JobSummary) => void;
+}) {
+  const [form, setForm] = useState<JobCreate>({
+    customer_id: '',
+    location_id: '',
+    title: '',
+    description: null,
+    service_type: null,
+    priority: 50,
+    estimated_duration_min: 60,
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const created = await createJobApi(form);
+      onCreated(created);
+    } catch (err) {
+      const apiErr = err as ApiError;
+      setError(apiErr?.detail ?? (err instanceof Error ? err.message : String(err)));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="w-full max-w-lg rounded-lg bg-white p-6 shadow-xl">
+        <h2 className="mb-4 text-lg font-semibold text-neutral-900">New Job</h2>
+        {error && (
+          <Alert variant="destructive" className="mb-4">
+            {error}
+          </Alert>
+        )}
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+          <div>
+            <label htmlFor="job-title" className="mb-1 block text-sm font-medium text-neutral-700">Title *</label>
+            <Input
+              id="job-title"
+              value={form.title}
+              onChange={(e) => setForm((f) => ({ ...f, title: e.target.value }))}
+              placeholder="e.g. Fix leaking pipe"
+              required
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="mb-1 block text-sm font-medium text-neutral-700">Customer ID *</label>
+              <Input
+                value={form.customer_id}
+                onChange={(e) => setForm((f) => ({ ...f, customer_id: e.target.value }))}
+                placeholder="UUID"
+                required
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium text-neutral-700">Location ID *</label>
+              <Input
+                value={form.location_id}
+                onChange={(e) => setForm((f) => ({ ...f, location_id: e.target.value }))}
+                placeholder="UUID"
+                required
+              />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="mb-1 block text-sm font-medium text-neutral-700">Service type</label>
+              <Input
+                value={form.service_type ?? ''}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, service_type: e.target.value || null }))
+                }
+                placeholder="e.g. Drain cleaning"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium text-neutral-700">Duration (min)</label>
+              <Input
+                type="number"
+                min={5}
+                max={1440}
+                value={form.estimated_duration_min}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, estimated_duration_min: Number(e.target.value) }))
+                }
+              />
+            </div>
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
+            <Button type="button" variant="ghost" onClick={onClose} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? 'Creating…' : 'Create job'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
 
 export const JobsPage: React.FC = () => {
-  const [items, setItems] = useState<DeadLetterItem[]>([]);
+  const [jobs, setJobs] = useState<JobSummary[]>([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [retryingId, setRetryingId] = useState<string | null>(null);
-  const [retryError, setRetryError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState<JobStatus | ''>('');
+  const [showCreate, setShowCreate] = useState(false);
 
-  const load = useCallback(async (): Promise<void> => {
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => clearTimeout(t);
+  }, [search]);
+
+  const load = useCallback(async (params: JobListParams) => {
     setLoading(true);
-    setError(null);
     try {
-      const data = await listDeadLetters(50, 0);
-      setItems(data.items);
+      const data = await listJobsApi(params);
+      setJobs(data.items);
       setTotal(data.total);
+      setError(null);
     } catch (err) {
       const apiErr = err as ApiError;
-      const detail = apiErr?.detail || (err instanceof Error ? err.message : String(err));
-      setError(detail);
+      setError(apiErr?.detail ?? (err instanceof Error ? err.message : String(err)));
     } finally {
       setLoading(false);
     }
   }, []);
 
   useEffect(() => {
-    void load();
-  }, [load]);
+    let cancelled = false;
+    void load({
+      search: debouncedSearch || undefined,
+      status: statusFilter || undefined,
+      limit: 50,
+    }).then(() => {
+      if (cancelled) return;
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [debouncedSearch, statusFilter, load]);
 
-  const handleRetry = async (eventId: string): Promise<void> => {
-    setRetryingId(eventId);
-    setRetryError(null);
-    try {
-      await retryDeadLetter(eventId);
-      await load();
-    } catch (err) {
-      const apiErr = err as ApiError;
-      const detail = apiErr?.detail || (err instanceof Error ? err.message : String(err));
-      setRetryError(detail);
-    } finally {
-      setRetryingId(null);
-    }
+  const handleCreated = (job: JobSummary) => {
+    setShowCreate(false);
+    setJobs((prev) => [job, ...prev]);
+    setTotal((t) => t + 1);
   };
-
-  if (loading) {
-    return (
-      <div>
-        <h1>Jobs</h1>
-        <h2 style={{ marginTop: 0, color: '#475569' }}>Dead-letter events</h2>
-        <p>Loading dead-letter events…</p>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div>
-        <h1>Jobs</h1>
-        <h2 style={{ marginTop: 0, color: '#475569' }}>Dead-letter events</h2>
-        <p role="alert" style={{ color: '#b00020' }}>
-          {error}
-        </p>
-        <button onClick={() => void load()}>Retry</button>
-      </div>
-    );
-  }
 
   return (
     <div>
-      <h1>Jobs</h1>
-      <h2 style={{ marginTop: 0, color: '#475569' }}>Dead-letter events</h2>
-      <p style={{ marginBottom: '0.75rem' }}>
-        {total} dead-lettered event{total === 1 ? '' : 's'}.{' '}
-        <button onClick={() => void load()}>Refresh</button>
-      </p>
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-neutral-900">Jobs</h1>
+          {!loading && (
+            <p className="mt-0.5 text-sm text-neutral-500">{total} job{total === 1 ? '' : 's'}</p>
+          )}
+        </div>
+        <Button onClick={() => setShowCreate(true)}>New job</Button>
+      </div>
 
-      {retryError && (
-        <p role="alert" style={{ color: '#b00020' }}>
-          {retryError}
-        </p>
+      <div className="mb-4 flex gap-3">
+        <Input
+          className="max-w-xs"
+          placeholder="Search jobs…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <select
+          className="rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value as JobStatus | '')}
+        >
+          {STATUS_FILTER_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {error && (
+        <Alert variant="destructive" className="mb-4" role="alert">
+          {error}
+        </Alert>
       )}
 
-      {items.length === 0 ? (
-        <p style={{ color: '#666' }}>No dead-letter events. </p>
+      {loading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-10 w-full" />
+          ))}
+        </div>
+      ) : jobs.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-neutral-300 py-12 text-center">
+          <p className="text-neutral-500">No jobs found.</p>
+          <Button className="mt-4" variant="ghost" onClick={() => setShowCreate(true)}>
+            Create your first job
+          </Button>
+        </div>
       ) : (
-        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-          <thead>
-            <tr>
-              <th style={{ textAlign: 'left', borderBottom: '1px solid #ddd', padding: '0.5rem' }}>Event ID</th>
-              <th style={{ textAlign: 'left', borderBottom: '1px solid #ddd', padding: '0.5rem' }}>Type</th>
-              <th style={{ textAlign: 'left', borderBottom: '1px solid #ddd', padding: '0.5rem' }}>Attempts</th>
-              <th style={{ textAlign: 'left', borderBottom: '1px solid #ddd', padding: '0.5rem' }}>Reason</th>
-              <th style={{ textAlign: 'left', borderBottom: '1px solid #ddd', padding: '0.5rem' }}>Action</th>
-            </tr>
-          </thead>
-          <tbody>
-            {items.map((item) => (
-              <tr key={item.id} data-testid="dead-letter-row">
-                <td style={{ borderBottom: '1px solid #f0f0f0', padding: '0.5rem' }}>
-                  <code>{item.id}</code>
-                </td>
-                <td style={{ borderBottom: '1px solid #f0f0f0', padding: '0.5rem' }}>{item.event_type}</td>
-                <td style={{ borderBottom: '1px solid #f0f0f0', padding: '0.5rem' }}>{item.attempt_count}</td>
-                <td style={{ borderBottom: '1px solid #f0f0f0', padding: '0.5rem' }}>
-                  {item.dead_letter_reason ?? '—'}
-                </td>
-                <td style={{ borderBottom: '1px solid #f0f0f0', padding: '0.5rem' }}>
-                  <button
-                    onClick={() => void handleRetry(item.id)}
-                    disabled={retryingId === item.id}
-                  >
-                    {retryingId === item.id ? 'Retrying…' : 'Retry'}
-                  </button>
-                </td>
-              </tr>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Title</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Service type</TableHead>
+              <TableHead>Scheduled</TableHead>
+              <TableHead>Priority</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {jobs.map((job) => (
+              <TableRow key={job.id} data-testid="job-row">
+                <TableCell className="font-medium">{job.title}</TableCell>
+                <TableCell>
+                  <StatusBadge status={job.status} />
+                </TableCell>
+                <TableCell className="text-neutral-500">{job.service_type ?? '—'}</TableCell>
+                <TableCell className="text-neutral-500">
+                  {job.scheduled_for
+                    ? new Date(job.scheduled_for).toLocaleString()
+                    : '—'}
+                </TableCell>
+                <TableCell className="text-neutral-500">{job.priority}</TableCell>
+              </TableRow>
             ))}
-          </tbody>
-        </table>
+          </TableBody>
+        </Table>
+      )}
+
+      {showCreate && (
+        <CreateJobModal onClose={() => setShowCreate(false)} onCreated={handleCreated} />
       )}
     </div>
   );

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -47,6 +47,67 @@ export type {
 
 // --- Admin entity types ---
 
+// Slice 10: Job management
+export type JobStatus = 'pending' | 'scheduled' | 'in_progress' | 'completed' | 'cancelled';
+
+export interface JobSummary {
+  id: string;
+  title: string;
+  status: JobStatus;
+  priority: number;
+  scheduled_for: string | null;
+  customer_id: string;
+  location_id: string;
+  industry: string;
+  service_type: string | null;
+}
+
+export interface JobRead extends JobSummary {
+  tenant_id: string;
+  description: string | null;
+  requested_at: string | null;
+  requested_until: string | null;
+  estimated_duration_min: number;
+  started_at: string | null;
+  completed_at: string | null;
+  cancelled_at: string | null;
+  cancel_reason: string | null;
+  custom_fields: Record<string, unknown>;
+  external_id: string | null;
+  created_by_user_id: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface JobCreate {
+  customer_id: string;
+  location_id: string;
+  title: string;
+  description?: string | null;
+  priority?: number;
+  service_type?: string | null;
+  requested_at?: string | null;
+  requested_until?: string | null;
+  estimated_duration_min?: number;
+  custom_fields?: Record<string, unknown>;
+}
+
+export interface JobListResponse {
+  items: JobSummary[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface JobListParams {
+  status?: JobStatus[];
+  customer_id?: string;
+  search?: string;
+  limit?: number;
+  offset?: number;
+}
+
+// Legacy stub — kept for mobile SDK backward compat
 export interface AdminJob {
   id: string;
   customer_name?: string;
@@ -108,6 +169,23 @@ export function normalizeList<T>(data: unknown): T[] {
 
 // --- Admin list endpoints (use axios `client` — auth header set by AuthProvider) ---
 
+export async function listJobsAdmin(params: JobListParams = {}): Promise<JobListResponse> {
+  const qs: Record<string, string> = {};
+  if (params.status?.length) qs['status'] = params.status.join(',');
+  if (params.customer_id) qs['customer_id'] = params.customer_id;
+  if (params.search) qs['search'] = params.search;
+  if (params.limit != null) qs['limit'] = String(params.limit);
+  if (params.offset != null) qs['offset'] = String(params.offset);
+  const { data } = await client.get<JobListResponse>('/jobs', { params: qs });
+  return data;
+}
+
+export async function createJobAdmin(body: JobCreate): Promise<JobRead> {
+  const { data } = await client.post<JobRead>('/jobs', body);
+  return data;
+}
+
+/** @deprecated Use listJobsAdmin instead */
 export async function listJobs(): Promise<AdminJob[]> {
   const { data } = await client.get<unknown>('/jobs');
   return normalizeList<AdminJob>(data);


### PR DESCRIPTION
## Summary

- Replaces placeholder dead-letter content on `JobsPage` with a real jobs management view
- Table with Title, Status (coloured badge), Service type, Scheduled date, Priority columns
- Debounced search (300ms) + status dropdown filter drive `listJobsApi` re-fetches
- `CreateJobModal` form: Title (required), Customer ID, Location ID, Service type, Duration
- Skeleton loading state, empty state with CTA, error `Alert` for API failures
- Adds `JobSummary`, `JobCreate`, `listJobsApi`, `createJobApi` to `apps/admin-web/src/api.ts`
- Mirrors types in `packages/api-client/src/index.ts` (`listJobsAdmin`, `createJobAdmin`)
- 7 Jest tests — all pass

## Test plan

- [ ] `pnpm --filter admin-web test` → 7/7 pass
- [ ] Verify skeleton renders on slow API
- [ ] Verify empty state shows "No jobs found"
- [ ] Verify create modal opens, submits, and new row appears at top
- [ ] Verify API error shows alert in modal and on page load failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)