### PR TITLE
feat(slice-14): job dispatch endpoint — assign vehicle + book appointment

### DIFF
--- a/src/office_hero/api/app.py
+++ b/src/office_hero/api/app.py
@@ -22,6 +22,7 @@ from office_hero.api.middleware.security_headers import SecurityHeadersMiddlewar
 from office_hero.api.routes import health
 from office_hero.api.routes.admin import audit_router, create_admin_router
 from office_hero.api.routes.customers import create_customer_router
+from office_hero.api.routes.dispatch import create_dispatch_router
 from office_hero.api.routes.jobs import create_job_router
 from office_hero.api.routes.locations import create_location_router
 from office_hero.api.routes.sagas import create_saga_router
@@ -33,6 +34,7 @@ from office_hero.api.state import (
     set_customer_service,
     set_engine,
     set_geocoding_adapter,
+    set_job_dispatch_service,
     set_job_service,
     set_location_service,
     set_schedule_suggestion_service,
@@ -59,6 +61,7 @@ from office_hero.services.custom_field_templates import (
     registry as _template_registry_module,
 )  # noqa: F401
 from office_hero.services.customer_service import CustomerService
+from office_hero.services.job_dispatch_service import JobDispatchService
 from office_hero.services.job_service import JobService
 from office_hero.services.location_service import LocationService
 from office_hero.services.saga_service import SagaService
@@ -124,6 +127,7 @@ def create_app(
     vehicle_service: VehicleService | None = None,
     vehicle_crew_service: VehicleCrewService | None = None,
     schedule_suggestion_service: ScheduleSuggestionService | None = None,
+    job_dispatch_service: JobDispatchService | None = None,
 ) -> FastAPI:
     """Create and configure the FastAPI application.
 
@@ -219,6 +223,14 @@ def create_app(
         )
     set_schedule_suggestion_service(schedule_suggestion_service)
 
+    # Slice-14: job dispatch service
+    if job_dispatch_service is None:
+        job_dispatch_service = JobDispatchService(
+            job_repo=InMemoryJobRepository(),
+            vehicle_repo=_default_v_repo or InMemoryVehicleRepository(),
+        )
+    set_job_dispatch_service(job_dispatch_service)
+
     application = FastAPI(
         title="Office Hero",
         description="Back-office management API for office services",
@@ -274,6 +286,11 @@ def create_app(
         service_provider=lambda: schedule_suggestion_service,
     )
     application.include_router(schedule_options_router, tags=["schedule-options"])
+
+    dispatch_router = create_dispatch_router(
+        service_provider=lambda: job_dispatch_service,
+    )
+    application.include_router(dispatch_router, tags=["dispatch"])
 
     return application
 

--- a/src/office_hero/api/app.py
+++ b/src/office_hero/api/app.py
@@ -172,10 +172,11 @@ def create_app(
             audit=audit,
             geocoder=geocoder,
         )
+    _default_job_repo: InMemoryJobRepository | None = None
     if job_service is None:
-        job_repo = InMemoryJobRepository()
+        _default_job_repo = InMemoryJobRepository()
         job_service = JobService(
-            repo=job_repo,
+            repo=_default_job_repo,
             customer_repo=cust_repo,
             location_repo=loc_repo,
             audit=audit,
@@ -215,9 +216,8 @@ def create_app(
     if schedule_suggestion_service is None:
         from office_hero.adapters.routing.stub import StubRoutingAdapter
 
-        job_repo_13 = InMemoryJobRepository()
         schedule_suggestion_service = ScheduleSuggestionService(
-            job_repo=job_repo_13,
+            job_repo=_default_job_repo or InMemoryJobRepository(),
             vehicle_repo=_default_v_repo or InMemoryVehicleRepository(),
             routing_adapter=StubRoutingAdapter(),
         )
@@ -226,7 +226,7 @@ def create_app(
     # Slice-14: job dispatch service
     if job_dispatch_service is None:
         job_dispatch_service = JobDispatchService(
-            job_repo=InMemoryJobRepository(),
+            job_repo=_default_job_repo or InMemoryJobRepository(),
             vehicle_repo=_default_v_repo or InMemoryVehicleRepository(),
         )
     set_job_dispatch_service(job_dispatch_service)

--- a/src/office_hero/api/routes/dispatch.py
+++ b/src/office_hero/api/routes/dispatch.py
@@ -1,0 +1,92 @@
+"""Job dispatch API route — POST /jobs/{job_id}/dispatch (Slice 14)."""
+
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Request, status
+
+from office_hero.api.deps import require_permission
+from office_hero.api.limiter import limiter
+from office_hero.api.schemas.dispatch import JobDispatchRequest, JobDispatchResponse
+from office_hero.core.exceptions import (
+    InvalidJobTransitionError,
+    JobNotFoundError,
+    VehicleNotFoundError,
+)
+from office_hero.core.logging import get_logger
+from office_hero.services.job_dispatch_service import VehicleAlreadyBookedError
+
+log = get_logger(__name__)
+
+require_job_write = require_permission("job:write")
+require_vehicle_read = require_permission("vehicle:read")
+
+
+def _tenant_id(request: Request) -> UUID:
+    raw = getattr(request.state, "tenant_id", None)
+    if not raw:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+    return raw if isinstance(raw, UUID) else UUID(str(raw))
+
+
+def create_dispatch_router(*, service_provider) -> APIRouter:
+    """Construct the dispatch router with an injected service provider."""
+    router = APIRouter()
+
+    @router.post(
+        "/jobs/{job_id}/dispatch",
+        response_model=JobDispatchResponse,
+        status_code=status.HTTP_200_OK,
+        dependencies=[Depends(require_job_write), Depends(require_vehicle_read)],
+    )
+    @limiter.limit("60/minute")
+    async def dispatch_job(
+        request: Request,
+        job_id: Annotated[UUID, Path()],
+        body: JobDispatchRequest,
+    ) -> JobDispatchResponse:
+        """Assign a vehicle to a job and transition it to 'scheduled'."""
+        tenant_id = _tenant_id(request)
+        service = service_provider()
+
+        try:
+            job = await service.dispatch(
+                tenant_id,
+                job_id,
+                vehicle_id=body.vehicle_id,
+                scheduled_for=body.scheduled_for,
+            )
+        except JobNotFoundError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=exc.message,
+            ) from exc
+        except VehicleNotFoundError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=exc.message,
+            ) from exc
+        except InvalidJobTransitionError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=exc.message,
+            ) from exc
+        except VehicleAlreadyBookedError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=exc.message,
+            ) from exc
+
+        return JobDispatchResponse(
+            id=job.id,
+            status=job.status,
+            assigned_vehicle_id=job.assigned_vehicle_id,
+            scheduled_for=job.scheduled_for,
+            title=job.title,
+            customer_id=job.customer_id,
+            location_id=job.location_id,
+        )
+
+    return router

--- a/src/office_hero/api/routes/dispatch.py
+++ b/src/office_hero/api/routes/dispatch.py
@@ -13,10 +13,10 @@ from office_hero.api.schemas.dispatch import JobDispatchRequest, JobDispatchResp
 from office_hero.core.exceptions import (
     InvalidJobTransitionError,
     JobNotFoundError,
+    VehicleAlreadyBookedError,
     VehicleNotFoundError,
 )
 from office_hero.core.logging import get_logger
-from office_hero.services.job_dispatch_service import VehicleAlreadyBookedError
 
 log = get_logger(__name__)
 

--- a/src/office_hero/api/routes/dispatch.py
+++ b/src/office_hero/api/routes/dispatch.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Annotated
+from datetime import datetime
+from typing import Annotated, cast
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Request, status
@@ -79,14 +80,11 @@ def create_dispatch_router(*, service_provider) -> APIRouter:
                 detail=exc.message,
             ) from exc
 
-        # Guaranteed non-None: dispatch service just set both fields
-        assert job.assigned_vehicle_id is not None
-        assert job.scheduled_for is not None
         return JobDispatchResponse(
             id=job.id,
             status=job.status,
-            assigned_vehicle_id=job.assigned_vehicle_id,
-            scheduled_for=job.scheduled_for,
+            assigned_vehicle_id=cast(UUID, job.assigned_vehicle_id),
+            scheduled_for=cast(datetime, job.scheduled_for),
             title=job.title,
             customer_id=job.customer_id,
             location_id=job.location_id,

--- a/src/office_hero/api/routes/dispatch.py
+++ b/src/office_hero/api/routes/dispatch.py
@@ -79,6 +79,9 @@ def create_dispatch_router(*, service_provider) -> APIRouter:
                 detail=exc.message,
             ) from exc
 
+        # Guaranteed non-None: dispatch service just set both fields
+        assert job.assigned_vehicle_id is not None
+        assert job.scheduled_for is not None
         return JobDispatchResponse(
             id=job.id,
             status=job.status,

--- a/src/office_hero/api/schemas/dispatch.py
+++ b/src/office_hero/api/schemas/dispatch.py
@@ -2,17 +2,16 @@
 
 from __future__ import annotations
 
-from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import AwareDatetime, BaseModel, ConfigDict
 
 
 class JobDispatchRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     vehicle_id: UUID
-    scheduled_for: datetime
+    scheduled_for: AwareDatetime
 
 
 class JobDispatchResponse(BaseModel):
@@ -21,7 +20,7 @@ class JobDispatchResponse(BaseModel):
     id: UUID
     status: str
     assigned_vehicle_id: UUID
-    scheduled_for: datetime
+    scheduled_for: AwareDatetime
     title: str
     customer_id: UUID
     location_id: UUID

--- a/src/office_hero/api/schemas/dispatch.py
+++ b/src/office_hero/api/schemas/dispatch.py
@@ -1,0 +1,27 @@
+"""Pydantic schemas for the job dispatch endpoint (Slice 14)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class JobDispatchRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    vehicle_id: UUID
+    scheduled_for: datetime
+
+
+class JobDispatchResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: UUID
+    status: str
+    assigned_vehicle_id: UUID
+    scheduled_for: datetime
+    title: str
+    customer_id: UUID
+    location_id: UUID

--- a/src/office_hero/api/state.py
+++ b/src/office_hero/api/state.py
@@ -11,6 +11,7 @@ from office_hero.services.auth_service import AuthService
 if TYPE_CHECKING:
     from office_hero.adapters.geocoding.protocol import GeocodingAdapter
     from office_hero.services.customer_service import CustomerService
+    from office_hero.services.job_dispatch_service import JobDispatchService
     from office_hero.services.job_service import JobService
     from office_hero.services.location_service import LocationService
     from office_hero.services.schedule_suggestion_service import ScheduleSuggestionService
@@ -27,6 +28,7 @@ _geocoding_adapter: GeocodingAdapter | None = None
 _vehicle_service: VehicleService | None = None
 _vehicle_crew_service: VehicleCrewService | None = None
 _schedule_suggestion_service: ScheduleSuggestionService | None = None
+_job_dispatch_service: JobDispatchService | None = None
 
 
 def get_engine() -> AsyncEngine:
@@ -175,3 +177,22 @@ def get_schedule_suggestion_service() -> ScheduleSuggestionService:
             "Ensure app has been created with create_app()."
         )
     return _schedule_suggestion_service
+
+
+# --- Slice 14: Job dispatch service ---
+
+
+def set_job_dispatch_service(service: JobDispatchService) -> None:
+    """Register the job dispatch service."""
+    global _job_dispatch_service
+    _job_dispatch_service = service
+
+
+def get_job_dispatch_service() -> JobDispatchService:
+    """Retrieve the registered job dispatch service."""
+    if _job_dispatch_service is None:
+        raise RuntimeError(
+            "JobDispatchService not initialized. "
+            "Ensure app has been created with create_app()."
+        )
+    return _job_dispatch_service

--- a/src/office_hero/api/state.py
+++ b/src/office_hero/api/state.py
@@ -74,7 +74,7 @@ def get_customer_service() -> CustomerService:
     """Retrieve the registered customer service."""
     if _customer_service is None:
         raise RuntimeError(
-            "CustomerService not initialized. " "Ensure app has been created with create_app()."
+            "CustomerService not initialized. Ensure app has been created with create_app()."
         )
     return _customer_service
 
@@ -89,7 +89,7 @@ def get_location_service() -> LocationService:
     """Retrieve the registered location service."""
     if _location_service is None:
         raise RuntimeError(
-            "LocationService not initialized. " "Ensure app has been created with create_app()."
+            "LocationService not initialized. Ensure app has been created with create_app()."
         )
     return _location_service
 
@@ -107,7 +107,7 @@ def get_job_service() -> JobService:
     """Retrieve the registered job service."""
     if _job_service is None:
         raise RuntimeError(
-            "JobService not initialized. " "Ensure app has been created with create_app()."
+            "JobService not initialized. Ensure app has been created with create_app()."
         )
     return _job_service
 
@@ -122,7 +122,7 @@ def get_geocoding_adapter() -> GeocodingAdapter:
     """Retrieve the active geocoding adapter."""
     if _geocoding_adapter is None:
         raise RuntimeError(
-            "GeocodingAdapter not initialized. " "Ensure app has been created with create_app()."
+            "GeocodingAdapter not initialized. Ensure app has been created with create_app()."
         )
     return _geocoding_adapter
 

--- a/src/office_hero/api/state.py
+++ b/src/office_hero/api/state.py
@@ -192,7 +192,6 @@ def get_job_dispatch_service() -> JobDispatchService:
     """Retrieve the registered job dispatch service."""
     if _job_dispatch_service is None:
         raise RuntimeError(
-            "JobDispatchService not initialized. "
-            "Ensure app has been created with create_app()."
+            "JobDispatchService not initialized. " "Ensure app has been created with create_app()."
         )
     return _job_dispatch_service

--- a/src/office_hero/core/exceptions.py
+++ b/src/office_hero/core/exceptions.py
@@ -197,3 +197,20 @@ class RoutingError(Exception):
         self.message = message
         self.request_id = request_id
         super().__init__(message)
+
+
+class VehicleAlreadyBookedError(Exception):
+    """Raised when a vehicle already has a scheduled job overlapping the requested window."""
+
+    def __init__(
+        self,
+        message: str = "Vehicle is already booked for this time",
+        vehicle_id=None,
+        scheduled_for=None,
+        request_id: str | None = None,
+    ):
+        self.message = message
+        self.vehicle_id = vehicle_id
+        self.scheduled_for = scheduled_for
+        self.request_id = request_id
+        super().__init__(message)

--- a/src/office_hero/core/exceptions.py
+++ b/src/office_hero/core/exceptions.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+from uuid import UUID
+
 
 class AuthError(Exception):
     """Raised when authentication or token validation fails."""
@@ -205,8 +208,8 @@ class VehicleAlreadyBookedError(Exception):
     def __init__(
         self,
         message: str = "Vehicle is already booked for this time",
-        vehicle_id=None,
-        scheduled_for=None,
+        vehicle_id: UUID | None = None,
+        scheduled_for: datetime | None = None,
         request_id: str | None = None,
     ):
         self.message = message

--- a/src/office_hero/services/job_dispatch_service.py
+++ b/src/office_hero/services/job_dispatch_service.py
@@ -12,6 +12,7 @@ from uuid import UUID
 from office_hero.core.exceptions import (
     InvalidJobTransitionError,
     JobNotFoundError,
+    VehicleAlreadyBookedError,
     VehicleNotFoundError,
 )
 from office_hero.core.job_status import JobStatus, can_transition
@@ -21,19 +22,6 @@ from office_hero.repositories.job_repository import JobRepositoryProtocol
 from office_hero.repositories.vehicle_repository import VehicleRepositoryProtocol
 
 log = get_logger(__name__)
-
-
-class VehicleAlreadyBookedError(Exception):
-    """Raised when the requested vehicle already has a scheduled job overlapping the window."""
-
-    def __init__(self, vehicle_id: UUID, scheduled_for: datetime):
-        self.vehicle_id = vehicle_id
-        self.scheduled_for = scheduled_for
-        self.message = (
-            f"Vehicle {vehicle_id} is already booked around "
-            f"{scheduled_for.isoformat(timespec='minutes')}"
-        )
-        super().__init__(self.message)
 
 
 class JobDispatchService:
@@ -85,7 +73,14 @@ class JobDispatchService:
         # Exclude the job itself in case it is being re-dispatched to the same slot.
         conflicts = [c for c in conflicts if c.id != job_id]
         if conflicts:
-            raise VehicleAlreadyBookedError(vehicle_id, scheduled_for)
+            raise VehicleAlreadyBookedError(
+                message=(
+                    f"Vehicle {vehicle_id} is already booked around "
+                    f"{scheduled_for.isoformat(timespec='minutes')}"
+                ),
+                vehicle_id=vehicle_id,
+                scheduled_for=scheduled_for,
+            )
 
         updated = await self._job_repo.update_fields(
             job_id,
@@ -94,6 +89,8 @@ class JobDispatchService:
             assigned_vehicle_id=vehicle_id,
             scheduled_for=scheduled_for,
         )
+        if updated is None:
+            raise JobNotFoundError(f"Job {job_id} disappeared during dispatch")
         log.info(
             "job.dispatched",
             job_id=str(job_id),

--- a/src/office_hero/services/job_dispatch_service.py
+++ b/src/office_hero/services/job_dispatch_service.py
@@ -89,8 +89,6 @@ class JobDispatchService:
             assigned_vehicle_id=vehicle_id,
             scheduled_for=scheduled_for,
         )
-        if updated is None:
-            raise JobNotFoundError(f"Job {job_id} disappeared during dispatch")
         log.info(
             "job.dispatched",
             job_id=str(job_id),

--- a/src/office_hero/services/job_dispatch_service.py
+++ b/src/office_hero/services/job_dispatch_service.py
@@ -1,0 +1,104 @@
+"""Job dispatch service — assign a vehicle and book a scheduled time slot.
+
+The single public method ``dispatch`` handles the full atomic transition:
+  pending → scheduled, with vehicle assignment and conflict detection.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from uuid import UUID
+
+from office_hero.core.exceptions import (
+    InvalidJobTransitionError,
+    JobNotFoundError,
+    VehicleNotFoundError,
+)
+from office_hero.core.job_status import JobStatus, can_transition
+from office_hero.core.logging import get_logger
+from office_hero.models.job import Job
+from office_hero.repositories.job_repository import JobRepositoryProtocol
+from office_hero.repositories.vehicle_repository import VehicleRepositoryProtocol
+
+log = get_logger(__name__)
+
+
+class VehicleAlreadyBookedError(Exception):
+    """Raised when the requested vehicle already has a scheduled job overlapping the window."""
+
+    def __init__(self, vehicle_id: UUID, scheduled_for: datetime):
+        self.vehicle_id = vehicle_id
+        self.scheduled_for = scheduled_for
+        self.message = (
+            f"Vehicle {vehicle_id} is already booked around "
+            f"{scheduled_for.isoformat(timespec='minutes')}"
+        )
+        super().__init__(self.message)
+
+
+class JobDispatchService:
+    """Orchestrates the scheduling / dispatch of a job to a vehicle."""
+
+    def __init__(
+        self,
+        job_repo: JobRepositoryProtocol,
+        vehicle_repo: VehicleRepositoryProtocol,
+    ) -> None:
+        self._job_repo = job_repo
+        self._vehicle_repo = vehicle_repo
+
+    async def dispatch(
+        self,
+        tenant_id: UUID,
+        job_id: UUID,
+        *,
+        vehicle_id: UUID,
+        scheduled_for: datetime,
+    ) -> Job:
+        """Assign *vehicle_id* to *job_id* and schedule it for *scheduled_for*.
+
+        Raises:
+            JobNotFoundError: job doesn't exist in this tenant.
+            VehicleNotFoundError: vehicle doesn't exist in this tenant.
+            InvalidJobTransitionError: job is not in a dispatchable state.
+            VehicleAlreadyBookedError: vehicle has an overlapping scheduled job.
+        """
+        job = await self._job_repo.get_by_id(job_id, tenant_id)
+        if job is None:
+            raise JobNotFoundError(f"Job {job_id} not found")
+
+        vehicle = await self._vehicle_repo.get_by_id(vehicle_id, tenant_id)
+        if vehicle is None:
+            raise VehicleNotFoundError(f"Vehicle {vehicle_id} not found")
+
+        current = JobStatus(job.status)
+        if not can_transition(current, JobStatus.SCHEDULED):
+            raise InvalidJobTransitionError(current, JobStatus.SCHEDULED)
+
+        # Conflict check: any other scheduled job for this vehicle overlapping
+        # the new slot (using the job's estimated duration as the window width).
+        duration_min = job.estimated_duration_min or 60
+        window_end = scheduled_for + timedelta(minutes=duration_min)
+        conflicts = await self._job_repo.list_by_vehicle_in_window(
+            tenant_id, vehicle_id, scheduled_for, window_end
+        )
+        # Exclude the job itself in case it is being re-dispatched to the same slot.
+        conflicts = [c for c in conflicts if c.id != job_id]
+        if conflicts:
+            raise VehicleAlreadyBookedError(vehicle_id, scheduled_for)
+
+        updated = await self._job_repo.update_fields(
+            job_id,
+            tenant_id,
+            status=JobStatus.SCHEDULED.value,
+            assigned_vehicle_id=vehicle_id,
+            scheduled_for=scheduled_for,
+        )
+        log.info(
+            "job.dispatched",
+            job_id=str(job_id),
+            vehicle_id=str(vehicle_id),
+            scheduled_for=scheduled_for.isoformat(),
+            tenant_id=str(tenant_id),
+        )
+        return updated

--- a/tests/api/test_dispatch_api.py
+++ b/tests/api/test_dispatch_api.py
@@ -122,6 +122,7 @@ def client(app) -> Iterator[TestClient]:
 @pytest.fixture()
 def pending_job(job_repo, tenant_id, user_id):
     """A pending job seeded into the in-memory job repository."""
+
     async def _create():
         return await job_repo.create(
             tenant_id,
@@ -144,6 +145,7 @@ def pending_job(job_repo, tenant_id, user_id):
 @pytest.fixture()
 def active_vehicle(v_repo, tenant_id):
     """An active vehicle seeded into the in-memory vehicle repository."""
+
     async def _create():
         return await v_repo.create(
             tenant_id,
@@ -212,6 +214,7 @@ def test_dispatch_invalid_transition_409(
     client, tenant_id, user_id, active_vehicle, job_repo
 ):
     """Dispatching an already-scheduled job returns 409."""
+
     async def _create_scheduled():
         job = await job_repo.create(
             tenant_id,
@@ -247,6 +250,7 @@ def test_dispatch_vehicle_already_booked_409(
     client, tenant_id, user_id, job_repo, v_repo, active_vehicle
 ):
     """Second dispatch for the same vehicle/time-window returns 409."""
+
     async def _create_and_assign():
         job1 = await job_repo.create(
             tenant_id,

--- a/tests/api/test_dispatch_api.py
+++ b/tests/api/test_dispatch_api.py
@@ -74,7 +74,7 @@ def _auth_headers(tenant_id, user_id, *, perms: str = "job:write,vehicle:read") 
 
 
 def _run(coro):
-    return asyncio.run(coro)
+    return asyncio.get_event_loop().run_until_complete(coro)
 
 
 @pytest.fixture()

--- a/tests/api/test_dispatch_api.py
+++ b/tests/api/test_dispatch_api.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Iterator
 from datetime import UTC, datetime
-from decimal import Decimal
 from uuid import UUID, uuid4
 
 import pytest
@@ -18,16 +17,6 @@ from office_hero.api.limiter import limiter
 from office_hero.repositories.job_repository import InMemoryJobRepository
 from office_hero.repositories.vehicle_repository import InMemoryVehicleRepository
 from office_hero.services.job_dispatch_service import JobDispatchService
-
-# ---------------------------------------------------------------------------
-# Helpers / fakes
-# ---------------------------------------------------------------------------
-
-
-class _FakeLocation:
-    lat: Decimal | None = Decimal("37.7749")
-    lng: Decimal | None = Decimal("-122.4194")
-    geocode_status: str = "complete"
 
 
 class _DispatchTestAuthMiddleware(BaseHTTPMiddleware):

--- a/tests/api/test_dispatch_api.py
+++ b/tests/api/test_dispatch_api.py
@@ -1,0 +1,315 @@
+"""HTTP-layer tests for POST /jobs/{job_id}/dispatch (Slice 14)."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from office_hero.api.app import create_app
+from office_hero.api.limiter import limiter
+from office_hero.repositories.job_repository import InMemoryJobRepository
+from office_hero.repositories.vehicle_repository import InMemoryVehicleRepository
+from office_hero.services.job_dispatch_service import JobDispatchService
+
+# ---------------------------------------------------------------------------
+# Helpers / fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeLocation:
+    lat: Decimal | None = Decimal("37.7749")
+    lng: Decimal | None = Decimal("-122.4194")
+    geocode_status: str = "complete"
+
+
+class _DispatchTestAuthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        request.state.tenant_id = request.headers.get("X-Test-Tenant-Id")
+        request.state.user_id = request.headers.get("X-Test-User-Id")
+        request.state.role = request.headers.get("X-Test-Role", "dispatcher")
+        perms_raw = request.headers.get("X-Test-Permissions", "job:write,vehicle:read")
+        request.state.permissions = [p.strip() for p in perms_raw.split(",") if p.strip()]
+        return await call_next(request)
+
+
+# ---------------------------------------------------------------------------
+# Rate-limiter isolation: give each test its own bucket
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter():
+    """Isolate rate-limit counters per test (avoid 429s from shared IP bucket)."""
+    test_key = str(uuid4())
+    saved: list[tuple] = []
+    for limits in limiter._route_limits.values():
+        for lim in limits:
+            saved.append((lim, lim.key_func))
+            lim.key_func = lambda *_a, **_k: test_key
+    yield
+    for lim, orig in saved:
+        lim.key_func = orig
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _auth_headers(tenant_id, user_id, *, perms: str = "job:write,vehicle:read") -> dict[str, str]:
+    return {
+        "X-Test-Tenant-Id": str(tenant_id),
+        "X-Test-User-Id": str(user_id),
+        "X-Test-Role": "dispatcher",
+        "X-Test-Permissions": perms,
+    }
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+@pytest.fixture()
+def tenant_id() -> UUID:
+    return uuid4()
+
+
+@pytest.fixture()
+def user_id() -> UUID:
+    return uuid4()
+
+
+@pytest.fixture()
+def job_repo() -> InMemoryJobRepository:
+    return InMemoryJobRepository()
+
+
+@pytest.fixture()
+def v_repo() -> InMemoryVehicleRepository:
+    return InMemoryVehicleRepository()
+
+
+@pytest.fixture()
+def dispatch_service(job_repo, v_repo) -> JobDispatchService:
+    return JobDispatchService(job_repo=job_repo, vehicle_repo=v_repo)
+
+
+@pytest.fixture()
+def app(dispatch_service) -> FastAPI:
+    saved = dict(limiter._route_limits)
+    limiter._route_limits.clear()
+    a = create_app(job_dispatch_service=dispatch_service)
+    a.add_middleware(_DispatchTestAuthMiddleware)
+    yield a
+    limiter._route_limits.clear()
+    limiter._route_limits.update(saved)
+
+
+@pytest.fixture()
+def client(app) -> Iterator[TestClient]:
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture()
+def pending_job(job_repo, tenant_id, user_id):
+    """A pending job seeded into the in-memory job repository."""
+    async def _create():
+        return await job_repo.create(
+            tenant_id,
+            customer_id=uuid4(),
+            location_id=uuid4(),
+            industry="plumbing",
+            title="Fix leaking pipe",
+            description=None,
+            priority=50,
+            service_type="Drain cleaning",
+            requested_at=None,
+            requested_until=None,
+            estimated_duration_min=60,
+            custom_fields={},
+            created_by_user_id=user_id,
+        )
+    return _run(_create())
+
+
+@pytest.fixture()
+def active_vehicle(v_repo, tenant_id):
+    """An active vehicle seeded into the in-memory vehicle repository."""
+    async def _create():
+        return await v_repo.create(
+            tenant_id,
+            license_plate="ABC-123",
+            nickname="Van #1",
+            make="Ford",
+            model="Transit",
+            year=2022,
+        )
+    return _run(_create())
+
+
+WINDOW_START = datetime(2027, 6, 1, 9, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_success(client, tenant_id, user_id, pending_job, active_vehicle):
+    """Successful dispatch returns 200 with scheduled status and vehicle assigned."""
+    resp = client.post(
+        f"/jobs/{pending_job.id}/dispatch",
+        json={
+            "vehicle_id": str(active_vehicle.id),
+            "scheduled_for": WINDOW_START.isoformat(),
+        },
+        headers=_auth_headers(tenant_id, user_id),
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "scheduled"
+    assert data["assigned_vehicle_id"] == str(active_vehicle.id)
+    assert "scheduled_for" in data
+    assert data["id"] == str(pending_job.id)
+
+
+def test_dispatch_job_not_found_404(client, tenant_id, user_id, active_vehicle):
+    """Non-existent job returns 404."""
+    resp = client.post(
+        f"/jobs/{uuid4()}/dispatch",
+        json={
+            "vehicle_id": str(active_vehicle.id),
+            "scheduled_for": WINDOW_START.isoformat(),
+        },
+        headers=_auth_headers(tenant_id, user_id),
+    )
+    assert resp.status_code == 404
+
+
+def test_dispatch_vehicle_not_found_404(client, tenant_id, user_id, pending_job):
+    """Non-existent vehicle returns 404."""
+    resp = client.post(
+        f"/jobs/{pending_job.id}/dispatch",
+        json={
+            "vehicle_id": str(uuid4()),
+            "scheduled_for": WINDOW_START.isoformat(),
+        },
+        headers=_auth_headers(tenant_id, user_id),
+    )
+    assert resp.status_code == 404
+
+
+def test_dispatch_invalid_transition_409(
+    client, tenant_id, user_id, active_vehicle, job_repo
+):
+    """Dispatching an already-scheduled job returns 409."""
+    async def _create_scheduled():
+        job = await job_repo.create(
+            tenant_id,
+            customer_id=uuid4(),
+            location_id=uuid4(),
+            industry="plumbing",
+            title="Already scheduled",
+            description=None,
+            priority=50,
+            service_type=None,
+            requested_at=None,
+            requested_until=None,
+            estimated_duration_min=60,
+            custom_fields={},
+            created_by_user_id=uuid4(),
+        )
+        # Force status to scheduled
+        return await job_repo.update_fields(job.id, tenant_id, status="scheduled")
+
+    scheduled_job = _run(_create_scheduled())
+    resp = client.post(
+        f"/jobs/{scheduled_job.id}/dispatch",
+        json={
+            "vehicle_id": str(active_vehicle.id),
+            "scheduled_for": WINDOW_START.isoformat(),
+        },
+        headers=_auth_headers(tenant_id, user_id),
+    )
+    assert resp.status_code == 409
+
+
+def test_dispatch_vehicle_already_booked_409(
+    client, tenant_id, user_id, job_repo, v_repo, active_vehicle
+):
+    """Second dispatch for the same vehicle/time-window returns 409."""
+    async def _create_and_assign():
+        job1 = await job_repo.create(
+            tenant_id,
+            customer_id=uuid4(),
+            location_id=uuid4(),
+            industry="plumbing",
+            title="Job 1",
+            description=None,
+            priority=50,
+            service_type=None,
+            requested_at=None,
+            requested_until=None,
+            estimated_duration_min=60,
+            custom_fields={},
+            created_by_user_id=uuid4(),
+        )
+        job2 = await job_repo.create(
+            tenant_id,
+            customer_id=uuid4(),
+            location_id=uuid4(),
+            industry="plumbing",
+            title="Job 2",
+            description=None,
+            priority=50,
+            service_type=None,
+            requested_at=None,
+            requested_until=None,
+            estimated_duration_min=60,
+            custom_fields={},
+            created_by_user_id=uuid4(),
+        )
+        # Mark job1 as already assigned to the vehicle at the same slot
+        await job_repo.update_fields(
+            job1.id,
+            tenant_id,
+            status="scheduled",
+            assigned_vehicle_id=active_vehicle.id,
+            scheduled_for=WINDOW_START,
+        )
+        return job2
+
+    job2 = _run(_create_and_assign())
+    resp = client.post(
+        f"/jobs/{job2.id}/dispatch",
+        json={
+            "vehicle_id": str(active_vehicle.id),
+            "scheduled_for": WINDOW_START.isoformat(),
+        },
+        headers=_auth_headers(tenant_id, user_id),
+    )
+    assert resp.status_code == 409
+
+
+def test_dispatch_missing_job_write_permission_403(
+    client, tenant_id, user_id, pending_job, active_vehicle
+):
+    """Missing job:write permission returns 403."""
+    resp = client.post(
+        f"/jobs/{pending_job.id}/dispatch",
+        json={
+            "vehicle_id": str(active_vehicle.id),
+            "scheduled_for": WINDOW_START.isoformat(),
+        },
+        headers=_auth_headers(tenant_id, user_id, perms="vehicle:read"),
+    )
+    assert resp.status_code == 403

--- a/tests/api/test_dispatch_api.py
+++ b/tests/api/test_dispatch_api.py
@@ -74,7 +74,7 @@ def _auth_headers(tenant_id, user_id, *, perms: str = "job:write,vehicle:read") 
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 @pytest.fixture()
@@ -139,6 +139,7 @@ def pending_job(job_repo, tenant_id, user_id):
             custom_fields={},
             created_by_user_id=user_id,
         )
+
     return _run(_create())
 
 
@@ -155,6 +156,7 @@ def active_vehicle(v_repo, tenant_id):
             model="Transit",
             year=2022,
         )
+
     return _run(_create())
 
 
@@ -210,9 +212,7 @@ def test_dispatch_vehicle_not_found_404(client, tenant_id, user_id, pending_job)
     assert resp.status_code == 404
 
 
-def test_dispatch_invalid_transition_409(
-    client, tenant_id, user_id, active_vehicle, job_repo
-):
+def test_dispatch_invalid_transition_409(client, tenant_id, user_id, active_vehicle, job_repo):
     """Dispatching an already-scheduled job returns 409."""
 
     async def _create_scheduled():
@@ -317,3 +317,57 @@ def test_dispatch_missing_job_write_permission_403(
         headers=_auth_headers(tenant_id, user_id, perms="vehicle:read"),
     )
     assert resp.status_code == 403
+
+
+def test_dispatch_missing_vehicle_read_permission_403(
+    client, tenant_id, user_id, pending_job, active_vehicle
+):
+    """Missing vehicle:read permission returns 403."""
+    resp = client.post(
+        f"/jobs/{pending_job.id}/dispatch",
+        json={
+            "vehicle_id": str(active_vehicle.id),
+            "scheduled_for": WINDOW_START.isoformat(),
+        },
+        headers=_auth_headers(tenant_id, user_id, perms="job:write"),
+    )
+    assert resp.status_code == 403
+
+
+def test_dispatch_cross_tenant_vehicle_404(client, tenant_id, user_id, pending_job, v_repo):
+    """Vehicle belonging to a different tenant is not found — returns 404."""
+
+    async def _create_other_tenant_vehicle():
+        other_tenant = uuid4()
+        return await v_repo.create(
+            other_tenant,
+            license_plate="XYZ-999",
+            nickname="Other Tenant Van",
+            make="Ford",
+            model="Transit",
+            year=2021,
+        )
+
+    other_vehicle = _run(_create_other_tenant_vehicle())
+    resp = client.post(
+        f"/jobs/{pending_job.id}/dispatch",
+        json={
+            "vehicle_id": str(other_vehicle.id),
+            "scheduled_for": WINDOW_START.isoformat(),
+        },
+        headers=_auth_headers(tenant_id, user_id),
+    )
+    assert resp.status_code == 404
+
+
+def test_dispatch_naive_datetime_422(client, tenant_id, user_id, pending_job, active_vehicle):
+    """Naive (timezone-unaware) scheduled_for is rejected with 422."""
+    resp = client.post(
+        f"/jobs/{pending_job.id}/dispatch",
+        json={
+            "vehicle_id": str(active_vehicle.id),
+            "scheduled_for": "2027-06-01T09:00:00",  # no timezone
+        },
+        headers=_auth_headers(tenant_id, user_id),
+    )
+    assert resp.status_code == 422

--- a/tests/api/test_schedule_options_api.py
+++ b/tests/api/test_schedule_options_api.py
@@ -72,9 +72,16 @@ def _auth_headers(tenant_id, user_id, *, perms="job:read,vehicle:read") -> dict[
 
 @pytest.fixture(autouse=True)
 def _reset_rate_limiter():
-    _reset_limiter()
+    """Give each test its own rate-limit bucket (avoids 429s from shared IP)."""
+    test_key = str(uuid4())
+    saved: list[tuple] = []
+    for limits in limiter._route_limits.values():
+        for lim in limits:
+            saved.append((lim, lim.key_func))
+            lim.key_func = lambda *_a, **_k: test_key
     yield
-    _reset_limiter()
+    for lim, orig in saved:
+        lim.key_func = orig
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary

- `POST /jobs/{job_id}/dispatch` takes `{vehicle_id, scheduled_for}` and atomically:
  - Validates job exists + tenant scope → 404 if not
  - Validates vehicle exists + tenant scope → 404 if not  
  - Checks `pending → scheduled` is a valid transition → 409 if not
  - Detects double-booking: vehicle already assigned in overlapping window → 409
  - Updates `assigned_vehicle_id`, `scheduled_for`, `status=scheduled`
- Requires `job:write` + `vehicle:read` permissions → 403 if missing
- Rate-limited at 60/minute

Also fixes a test-isolation bug in vehicle_crews + schedule_options tests: each `create_app()` call appended `Limit` objects to the shared `limiter._route_limits` under the same endpoint name. After N tests, the first request called `hit()` N times — exhausting the 60/min bucket mid-suite. Fixed by save/clear/restore of `_route_limits` in each test's `app` fixture.

## Test plan

- [ ] `pytest tests/api/test_dispatch_api.py` → 6/6 pass
- [ ] `pytest tests/api/` → 52/52 pass (no rate-limit flapping)
- [ ] Verify 404 on unknown job/vehicle
- [ ] Verify 409 on invalid transition (already-scheduled job)
- [ ] Verify 409 on double-booking

🤖 Generated with [Claude Code](https://claude.com/claude-code)