### PR TITLE
feat(slice 13): Routing engine + schedule suggestions

### DIFF
--- a/alembic/versions/0007_job_vehicle_assignment.py
+++ b/alembic/versions/0007_job_vehicle_assignment.py
@@ -1,0 +1,52 @@
+"""Add assigned_vehicle_id to jobs table (Slice 13: routing engine)
+
+Revision ID: 0007_job_vehicle_assignment
+Revises: 0006_vehicles_and_crews
+Create Date: 2026-05-28 00:00:00.000000
+
+Adds:
+  * ``assigned_vehicle_id`` UUID NULLABLE FK → vehicles.id on ``jobs``
+  * Composite index ``idx_jobs_tenant_vehicle`` on ``(tenant_id, assigned_vehicle_id)``
+
+No new RLS policy is needed — the jobs table RLS policy already pins
+row visibility to ``current_setting('app.tenant_id')::uuid``.
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "0007_job_vehicle_assignment"
+down_revision = "0006_vehicles_and_crews"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "assigned_vehicle_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+    )
+    op.create_foreign_key(
+        "fk_jobs_assigned_vehicle",
+        "jobs",
+        "vehicles",
+        ["assigned_vehicle_id"],
+        ["id"],
+    )
+    op.create_index(
+        "idx_jobs_tenant_vehicle",
+        "jobs",
+        ["tenant_id", "assigned_vehicle_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_jobs_tenant_vehicle", table_name="jobs")
+    op.drop_constraint("fk_jobs_assigned_vehicle", "jobs", type_="foreignkey")
+    op.drop_column("jobs", "assigned_vehicle_id")

--- a/src/office_hero/adapters/routing/factory.py
+++ b/src/office_hero/adapters/routing/factory.py
@@ -1,0 +1,19 @@
+"""Factory for building a :class:`RoutingAdapter` from environment."""
+
+from __future__ import annotations
+
+import os
+
+from office_hero.adapters.routing.protocol import RoutingAdapter
+from office_hero.adapters.routing.stub import StubRoutingAdapter
+
+
+def build_routing_adapter() -> RoutingAdapter:
+    """Return StubRoutingAdapter unless ORS_API_KEY is set in the environment."""
+    api_key = os.environ.get("ORS_API_KEY", "").strip()
+    if not api_key:
+        return StubRoutingAdapter()
+
+    from office_hero.adapters.routing.ors import ORSRoutingAdapter
+
+    return ORSRoutingAdapter(api_key=api_key)

--- a/src/office_hero/adapters/routing/ors.py
+++ b/src/office_hero/adapters/routing/ors.py
@@ -1,0 +1,59 @@
+"""OpenRouteService routing adapter.
+
+POSTs to ORS v2 directions API and extracts duration/distance from the first
+route summary. Requires ``ORS_API_KEY`` environment variable.
+
+Raises :class:`~office_hero.core.exceptions.RoutingError` on any network or
+parse failure so callers can fall back gracefully.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+
+from office_hero.adapters.routing.protocol import RouteResult, RoutingAdapter
+from office_hero.core.exceptions import RoutingError
+
+_ORS_URL = "https://api.openrouteservice.org/v2/directions/driving-car"
+_TIMEOUT_S = 5.0
+
+
+class ORSRoutingAdapter(RoutingAdapter):
+    """Live ORS routing adapter (requires ORS_API_KEY)."""
+
+    def __init__(self, api_key: str | None = None) -> None:
+        self._api_key = api_key or os.environ.get("ORS_API_KEY", "")
+
+    async def get_route(
+        self,
+        from_lat: float,
+        from_lng: float,
+        to_lat: float,
+        to_lng: float,
+    ) -> RouteResult | None:
+        payload = {
+            "coordinates": [[from_lng, from_lat], [to_lng, to_lat]],
+            "profile": "driving-car",
+        }
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT_S) as client:
+                resp = await client.post(_ORS_URL, json=payload, headers=headers)
+                resp.raise_for_status()
+                data = resp.json()
+        except httpx.HTTPError as exc:
+            raise RoutingError(f"ORS request failed: {exc}") from exc
+
+        try:
+            summary = data["routes"][0]["summary"]
+            return RouteResult(
+                duration_seconds=int(summary["duration"]),
+                distance_meters=int(summary["distance"]),
+            )
+        except (KeyError, IndexError, TypeError, ValueError) as exc:
+            raise RoutingError(f"ORS response parse failed: {exc}") from exc

--- a/src/office_hero/adapters/routing/protocol.py
+++ b/src/office_hero/adapters/routing/protocol.py
@@ -1,0 +1,37 @@
+"""RoutingAdapter protocol + result dataclass (ADR 058).
+
+Decouples travel-time estimation from the service layer so concrete
+implementations (ORS, stub) can be swapped without touching business logic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class RouteResult:
+    """Estimated route between two coordinates."""
+
+    duration_seconds: int
+    distance_meters: int
+
+
+@runtime_checkable
+class RoutingAdapter(Protocol):
+    """Estimate travel time between two lat/lng points.
+
+    Implementations must be async. On network or parse failure they should
+    raise :class:`~office_hero.core.exceptions.RoutingError`. Returning
+    ``None`` is reserved for cases where the routing service responds
+    successfully but cannot find a route (e.g. unreachable coordinates).
+    """
+
+    async def get_route(
+        self,
+        from_lat: float,
+        from_lng: float,
+        to_lat: float,
+        to_lng: float,
+    ) -> RouteResult | None: ...

--- a/src/office_hero/adapters/routing/stub.py
+++ b/src/office_hero/adapters/routing/stub.py
@@ -1,0 +1,27 @@
+"""Stub routing adapter — deterministic ~15-minute estimate for any pair.
+
+Used in unit/API tests and as the default when ``ORS_API_KEY`` is not set.
+"""
+
+from __future__ import annotations
+
+from office_hero.adapters.routing.protocol import RouteResult, RoutingAdapter
+
+_STUB_DURATION_S = 900
+_STUB_DISTANCE_M = 12_000
+
+
+class StubRoutingAdapter(RoutingAdapter):
+    """Returns a fixed ~15-minute / 12 km estimate for any coordinate pair."""
+
+    async def get_route(
+        self,
+        from_lat: float,
+        from_lng: float,
+        to_lat: float,
+        to_lng: float,
+    ) -> RouteResult:
+        return RouteResult(
+            duration_seconds=_STUB_DURATION_S,
+            distance_meters=_STUB_DISTANCE_M,
+        )

--- a/src/office_hero/api/app.py
+++ b/src/office_hero/api/app.py
@@ -25,6 +25,7 @@ from office_hero.api.routes.customers import create_customer_router
 from office_hero.api.routes.jobs import create_job_router
 from office_hero.api.routes.locations import create_location_router
 from office_hero.api.routes.sagas import create_saga_router
+from office_hero.api.routes.schedule_options import create_schedule_options_router
 from office_hero.api.routes.vehicle_crews import create_vehicle_crew_router
 from office_hero.api.routes.vehicles import create_vehicle_router
 from office_hero.api.state import (
@@ -34,6 +35,7 @@ from office_hero.api.state import (
     set_geocoding_adapter,
     set_job_service,
     set_location_service,
+    set_schedule_suggestion_service,
     set_vehicle_crew_service,
     set_vehicle_service,
 )
@@ -60,6 +62,7 @@ from office_hero.services.customer_service import CustomerService
 from office_hero.services.job_service import JobService
 from office_hero.services.location_service import LocationService
 from office_hero.services.saga_service import SagaService
+from office_hero.services.schedule_suggestion_service import ScheduleSuggestionService
 from office_hero.services.vehicle_crew_service import VehicleCrewService
 from office_hero.services.vehicle_service import VehicleService
 
@@ -120,6 +123,7 @@ def create_app(
     job_service: JobService | None = None,
     vehicle_service: VehicleService | None = None,
     vehicle_crew_service: VehicleCrewService | None = None,
+    schedule_suggestion_service: ScheduleSuggestionService | None = None,
 ) -> FastAPI:
     """Create and configure the FastAPI application.
 
@@ -179,27 +183,41 @@ def create_app(
     set_job_service(job_service)
 
     # Slice-12 defaults: in-memory vehicle repos
+    _default_v_repo: InMemoryVehicleRepository | None = None
     if vehicle_service is None or vehicle_crew_service is None:
         v_audit = InMemoryAuditService()
-        v_repo = InMemoryVehicleRepository()
+        _default_v_repo = InMemoryVehicleRepository()
         vc_repo = InMemoryVehicleCrewRepository()
+        _default_v_repo._crew_repo = vc_repo  # cross-reference for list_active_for_date
 
         class _NoopUserRepo:
             async def get_by_id(self, user_id, tenant_id):
                 return None
 
         if vehicle_service is None:
-            vehicle_service = VehicleService(repo=v_repo, audit=v_audit, crew_repo=vc_repo)
+            vehicle_service = VehicleService(repo=_default_v_repo, audit=v_audit, crew_repo=vc_repo)
         if vehicle_crew_service is None:
             vehicle_crew_service = VehicleCrewService(
                 crew_repo=vc_repo,
-                vehicle_repo=v_repo,
+                vehicle_repo=_default_v_repo,
                 user_repo=_NoopUserRepo(),
                 audit=v_audit,
             )
 
     set_vehicle_service(vehicle_service)
     set_vehicle_crew_service(vehicle_crew_service)
+
+    # Slice-13: schedule suggestion service
+    if schedule_suggestion_service is None:
+        from office_hero.adapters.routing.stub import StubRoutingAdapter
+
+        job_repo_13 = InMemoryJobRepository()
+        schedule_suggestion_service = ScheduleSuggestionService(
+            job_repo=job_repo_13,
+            vehicle_repo=_default_v_repo or InMemoryVehicleRepository(),
+            routing_adapter=StubRoutingAdapter(),
+        )
+    set_schedule_suggestion_service(schedule_suggestion_service)
 
     application = FastAPI(
         title="Office Hero",
@@ -251,6 +269,11 @@ def create_app(
         vehicle_service_provider=lambda: vehicle_service,
     )
     application.include_router(crew_router, tags=["crews"])
+
+    schedule_options_router = create_schedule_options_router(
+        service_provider=lambda: schedule_suggestion_service,
+    )
+    application.include_router(schedule_options_router, tags=["schedule-options"])
 
     return application
 

--- a/src/office_hero/api/exception_handlers.py
+++ b/src/office_hero/api/exception_handlers.py
@@ -14,6 +14,7 @@ from office_hero.core.exceptions import (
     InvalidJobTransitionError,
     JobNotFoundError,
     PermissionError,
+    RoutingError,
     TenantError,
     VehicleCrewNotFoundError,
     VehicleNotFoundError,
@@ -191,6 +192,16 @@ async def rate_limit_error_handler(request: Request, exc: RateLimitExceeded) -> 
     )
 
 
+async def routing_error_handler(request: Request, exc: RoutingError) -> JSONResponse:
+    """Convert RoutingError to 503 Service Unavailable."""
+    request_id = getattr(request.state, "request_id", None)
+    log.warning("routing.error", message=exc.message, request_id=request_id)
+    return JSONResponse(
+        status_code=503,
+        content={"detail": exc.message, "request_id": request_id},
+    )
+
+
 def register_exception_handlers(app) -> None:
     """Register all global exception handlers on the FastAPI app."""
     app.add_exception_handler(AuthError, auth_error_handler)
@@ -203,5 +214,6 @@ def register_exception_handlers(app) -> None:
     app.add_exception_handler(VehicleCrewNotFoundError, vehicle_crew_not_found_handler)
     app.add_exception_handler(CrewAssignmentConflictError, crew_assignment_conflict_handler)
     app.add_exception_handler(InvalidCrewMemberError, invalid_crew_member_handler)
+    app.add_exception_handler(RoutingError, routing_error_handler)
     app.add_exception_handler(RateLimitExceeded, rate_limit_error_handler)
     app.add_exception_handler(Exception, unhandled_exception_handler)

--- a/src/office_hero/api/routes/schedule_options.py
+++ b/src/office_hero/api/routes/schedule_options.py
@@ -1,0 +1,86 @@
+"""Schedule-options API route — POST /jobs/{job_id}/schedule-options (Slice 13)."""
+
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Request, status
+
+from office_hero.api.deps import require_permission
+from office_hero.api.limiter import limiter
+from office_hero.api.schemas.schedule_option import (
+    ScheduleOptionItem,
+    ScheduleOptionRequest,
+    ScheduleOptionsResponse,
+)
+from office_hero.core.exceptions import JobNotFoundError, SchedulingNotAvailableError
+from office_hero.core.logging import get_logger
+
+log = get_logger(__name__)
+
+require_job_read = require_permission("job:read")
+require_vehicle_read = require_permission("vehicle:read")
+
+
+def _tenant_id(request: Request) -> UUID:
+    raw = getattr(request.state, "tenant_id", None)
+    if not raw:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+    return raw if isinstance(raw, UUID) else UUID(str(raw))
+
+
+def create_schedule_options_router(*, service_provider) -> APIRouter:
+    """Construct the schedule-options router with an injected service provider."""
+    router = APIRouter()
+
+    @router.post(
+        "/jobs/{job_id}/schedule-options",
+        response_model=ScheduleOptionsResponse,
+        dependencies=[Depends(require_job_read), Depends(require_vehicle_read)],
+    )
+    @limiter.limit("60/minute")
+    async def get_schedule_options(
+        request: Request,
+        job_id: Annotated[UUID, Path()],
+        body: ScheduleOptionRequest,
+    ) -> ScheduleOptionsResponse:
+        """Return ranked schedule suggestions for a job within a time window."""
+        tenant_id = _tenant_id(request)
+        service = service_provider()
+
+        try:
+            options = await service.get_options(
+                tenant_id,
+                job_id,
+                window_start=body.window_start,
+                window_end=body.window_end,
+                max_results=body.max_results,
+            )
+        except JobNotFoundError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=exc.message,
+            ) from exc
+        except SchedulingNotAvailableError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=exc.message,
+            ) from exc
+
+        return ScheduleOptionsResponse(
+            job_id=job_id,
+            options=[
+                ScheduleOptionItem(
+                    vehicle_id=opt.vehicle_id,
+                    vehicle_display=opt.vehicle_display,
+                    suggested_start=opt.suggested_start,
+                    travel_seconds=opt.travel_seconds,
+                    distance_meters=opt.distance_meters,
+                    rank=opt.rank,
+                )
+                for opt in options
+            ],
+        )
+
+    return router

--- a/src/office_hero/api/schemas/schedule_option.py
+++ b/src/office_hero/api/schemas/schedule_option.py
@@ -1,0 +1,34 @@
+"""Pydantic schemas for the schedule-options endpoint (Slice 13)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ScheduleOptionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    window_start: datetime
+    window_end: datetime
+    max_results: int = Field(default=3, ge=1, le=10)
+
+
+class ScheduleOptionItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    vehicle_id: UUID
+    vehicle_display: str
+    suggested_start: datetime
+    travel_seconds: int
+    distance_meters: int
+    rank: int
+
+
+class ScheduleOptionsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    job_id: UUID
+    options: list[ScheduleOptionItem]

--- a/src/office_hero/api/state.py
+++ b/src/office_hero/api/state.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from office_hero.services.customer_service import CustomerService
     from office_hero.services.job_service import JobService
     from office_hero.services.location_service import LocationService
+    from office_hero.services.schedule_suggestion_service import ScheduleSuggestionService
     from office_hero.services.vehicle_crew_service import VehicleCrewService
     from office_hero.services.vehicle_service import VehicleService
 
@@ -25,6 +26,7 @@ _job_service: JobService | None = None
 _geocoding_adapter: GeocodingAdapter | None = None
 _vehicle_service: VehicleService | None = None
 _vehicle_crew_service: VehicleCrewService | None = None
+_schedule_suggestion_service: ScheduleSuggestionService | None = None
 
 
 def get_engine() -> AsyncEngine:
@@ -154,3 +156,22 @@ def get_vehicle_crew_service() -> VehicleCrewService:
             "VehicleCrewService not initialized. Ensure app has been created with create_app()."
         )
     return _vehicle_crew_service
+
+
+# --- Slice 13: Schedule suggestion service ---
+
+
+def set_schedule_suggestion_service(service: ScheduleSuggestionService) -> None:
+    """Register the schedule suggestion service."""
+    global _schedule_suggestion_service
+    _schedule_suggestion_service = service
+
+
+def get_schedule_suggestion_service() -> ScheduleSuggestionService:
+    """Retrieve the registered schedule suggestion service."""
+    if _schedule_suggestion_service is None:
+        raise RuntimeError(
+            "ScheduleSuggestionService not initialized. "
+            "Ensure app has been created with create_app()."
+        )
+    return _schedule_suggestion_service

--- a/src/office_hero/core/exceptions.py
+++ b/src/office_hero/core/exceptions.py
@@ -181,51 +181,6 @@ class InvalidCrewMemberError(Exception):
         super().__init__(message)
 
 
-class JobNotFoundError(Exception):
-    """Raised when a job cannot be located in the caller's tenant scope."""
-
-    def __init__(self, message: str = "Job not found", request_id: str | None = None):
-        self.message = message
-        self.request_id = request_id
-        super().__init__(message)
-
-
-class InvalidJobTransitionError(Exception):
-    """Raised when an illegal job status transition is attempted."""
-
-    def __init__(
-        self,
-        from_status,
-        to_status,
-        message: str | None = None,
-        request_id: str | None = None,
-    ):
-        from office_hero.core.job_status import JobStatus
-
-        self.from_status: JobStatus = from_status
-        self.to_status: JobStatus = to_status
-        self.message = message or (f"Invalid job status transition: {from_status} -> {to_status}")
-        self.request_id = request_id
-        super().__init__(self.message)
-
-
-class CustomFieldValidationError(Exception):
-    """Raised when custom_fields fail industry-template validation."""
-
-    def __init__(
-        self,
-        field_name: str,
-        errors: list[str],
-        message: str | None = None,
-        request_id: str | None = None,
-    ):
-        self.field_name = field_name
-        self.errors = errors
-        self.message = message or f"Custom field validation failed for '{field_name}'"
-        self.request_id = request_id
-        super().__init__(self.message)
-
-
 class SchedulingNotAvailableError(Exception):
     """Raised when schedule suggestions cannot be generated for a job."""
 

--- a/src/office_hero/core/exceptions.py
+++ b/src/office_hero/core/exceptions.py
@@ -179,3 +179,66 @@ class InvalidCrewMemberError(Exception):
         self.reason = reason
         self.request_id = request_id
         super().__init__(message)
+
+
+class JobNotFoundError(Exception):
+    """Raised when a job cannot be located in the caller's tenant scope."""
+
+    def __init__(self, message: str = "Job not found", request_id: str | None = None):
+        self.message = message
+        self.request_id = request_id
+        super().__init__(message)
+
+
+class InvalidJobTransitionError(Exception):
+    """Raised when an illegal job status transition is attempted."""
+
+    def __init__(
+        self,
+        from_status,
+        to_status,
+        message: str | None = None,
+        request_id: str | None = None,
+    ):
+        from office_hero.core.job_status import JobStatus
+
+        self.from_status: JobStatus = from_status
+        self.to_status: JobStatus = to_status
+        self.message = message or (f"Invalid job status transition: {from_status} -> {to_status}")
+        self.request_id = request_id
+        super().__init__(self.message)
+
+
+class CustomFieldValidationError(Exception):
+    """Raised when custom_fields fail industry-template validation."""
+
+    def __init__(
+        self,
+        field_name: str,
+        errors: list[str],
+        message: str | None = None,
+        request_id: str | None = None,
+    ):
+        self.field_name = field_name
+        self.errors = errors
+        self.message = message or f"Custom field validation failed for '{field_name}'"
+        self.request_id = request_id
+        super().__init__(self.message)
+
+
+class SchedulingNotAvailableError(Exception):
+    """Raised when schedule suggestions cannot be generated for a job."""
+
+    def __init__(self, message: str = "Scheduling not available", request_id: str | None = None):
+        self.message = message
+        self.request_id = request_id
+        super().__init__(message)
+
+
+class RoutingError(Exception):
+    """Raised when a routing adapter fails (network, timeout, parse)."""
+
+    def __init__(self, message: str = "Routing failed", request_id: str | None = None):
+        self.message = message
+        self.request_id = request_id
+        super().__init__(message)

--- a/src/office_hero/models/job.py
+++ b/src/office_hero/models/job.py
@@ -24,6 +24,7 @@ from office_hero.models import Base
 if TYPE_CHECKING:
     from office_hero.models.customer import Customer
     from office_hero.models.location import Location
+    from office_hero.models.vehicle import Vehicle
 
 
 class Job(Base):
@@ -79,6 +80,11 @@ class Job(Base):
     # Back-office integration identifier (ADR 056).
     external_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
+    # Slice 13: vehicle assigned by the routing / scheduling engine.
+    assigned_vehicle_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey("vehicles.id"), nullable=True
+    )
+
     created_by_user_id: Mapped[UUID] = mapped_column(
         PG_UUID(as_uuid=True), ForeignKey("users.id"), nullable=False
     )
@@ -94,6 +100,7 @@ class Job(Base):
 
     customer: Mapped[Customer] = relationship("Customer")
     location: Mapped[Location] = relationship("Location")
+    vehicle: Mapped[Vehicle | None] = relationship("Vehicle")
 
     __table_args__ = (
         # Dispatch dashboard: filter by status within a tenant.
@@ -102,6 +109,8 @@ class Job(Base):
         Index("idx_jobs_tenant_scheduled_for", "tenant_id", "scheduled_for"),
         # Customer detail view: all jobs for a customer.
         Index("idx_jobs_tenant_customer", "tenant_id", "customer_id"),
+        # Routing engine: jobs assigned to a specific vehicle within a tenant.
+        Index("idx_jobs_tenant_vehicle", "tenant_id", "assigned_vehicle_id"),
         # GIN index for JSONB containment queries on custom_fields.
         # jsonb_path_ops is chosen for smallest index size; note it only
         # supports @> (containment) — a ? key-existence index is future work.

--- a/src/office_hero/repositories/job_repository.py
+++ b/src/office_hero/repositories/job_repository.py
@@ -74,6 +74,14 @@ class JobRepositoryProtocol(Protocol):
 
     async def list_due_for_routing(self, tenant_id: UUID, for_date: date) -> list[Job]: ...
 
+    async def list_by_vehicle_in_window(
+        self,
+        tenant_id: UUID,
+        vehicle_id: UUID,
+        window_start: datetime,
+        window_end: datetime,
+    ) -> list[Job]: ...
+
 
 class JobRepository:
     """SQLAlchemy-backed concrete :class:`Job` repository (ADR 058)."""
@@ -221,6 +229,25 @@ class JobRepository:
         result = await self.session.execute(stmt)
         return list(result.scalars().all())
 
+    async def list_by_vehicle_in_window(
+        self,
+        tenant_id: UUID,
+        vehicle_id: UUID,
+        window_start: datetime,
+        window_end: datetime,
+    ) -> list[Job]:
+        """Return scheduled/in_progress jobs for a vehicle that overlap the window."""
+        stmt = select(Job).where(
+            Job.tenant_id == tenant_id,
+            Job.assigned_vehicle_id == vehicle_id,
+            Job.status.in_(["scheduled", "in_progress"]),
+            Job.scheduled_for < window_end,
+            Job.scheduled_for + func.make_interval(0, 0, 0, 0, 0, Job.estimated_duration_min)
+            > window_start,
+        )
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())
+
 
 class InMemoryJobRepository:
     """In-memory mock implementing :class:`JobRepositoryProtocol`.
@@ -255,6 +282,7 @@ class InMemoryJobRepository:
             cancel_reason=row.get("cancel_reason"),
             custom_fields=deepcopy(row.get("custom_fields", {})),
             external_id=row.get("external_id"),
+            assigned_vehicle_id=row.get("assigned_vehicle_id"),
             created_by_user_id=row["created_by_user_id"],
         )
         job.created_at = row["created_at"]
@@ -302,6 +330,7 @@ class InMemoryJobRepository:
             "cancel_reason": None,
             "custom_fields": deepcopy(custom_fields or {}),
             "external_id": None,
+            "assigned_vehicle_id": None,
             "created_by_user_id": created_by_user_id,
             "created_at": now,
             "updated_at": now,
@@ -408,3 +437,30 @@ class InMemoryJobRepository:
         ]
         rows.sort(key=lambda r: (r["priority"], r.get("scheduled_for") or datetime.max))
         return [self._row_to_job(r) for r in rows]
+
+    async def list_by_vehicle_in_window(
+        self,
+        tenant_id: UUID,
+        vehicle_id: UUID,
+        window_start: datetime,
+        window_end: datetime,
+    ) -> list[Job]:
+        """Return scheduled/in_progress jobs for a vehicle that overlap the window."""
+        from datetime import timedelta
+
+        result = []
+        for r in self._rows.values():
+            if r["tenant_id"] != tenant_id:
+                continue
+            if r.get("assigned_vehicle_id") != vehicle_id:
+                continue
+            if r["status"] not in ("scheduled", "in_progress"):
+                continue
+            sf = r.get("scheduled_for")
+            if sf is None:
+                continue
+            duration = timedelta(minutes=r.get("estimated_duration_min", 60))
+            job_end = sf + duration
+            if sf < window_end and job_end > window_start:
+                result.append(self._row_to_job(r))
+        return result

--- a/src/office_hero/repositories/vehicle_repository.py
+++ b/src/office_hero/repositories/vehicle_repository.py
@@ -63,6 +63,8 @@ class VehicleRepositoryProtocol(Protocol):
 
     async def list_active_for_date(self, tenant_id: UUID, work_date: date) -> list[Vehicle]: ...
 
+    async def list_active(self, tenant_id: UUID) -> list[Vehicle]: ...
+
 
 class VehicleRepository:
     """SQLAlchemy-backed concrete :class:`Vehicle` repository (ADR 058)."""
@@ -180,6 +182,15 @@ class VehicleRepository:
                 VehicleCrew.work_date == work_date,
             )
             .distinct()
+        )
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def list_active(self, tenant_id: UUID) -> list[Vehicle]:
+        """Return all non-archived vehicles for a tenant."""
+        stmt = select(Vehicle).where(
+            Vehicle.tenant_id == tenant_id,
+            Vehicle.archived.is_(False),
         )
         result = await self.session.execute(stmt)
         return list(result.scalars().all())
@@ -342,4 +353,12 @@ class InMemoryVehicleRepository:
             if r["tenant_id"] == tenant_id
             and not r.get("archived", False)
             and r["id"] in crew_vehicle_ids
+        ]
+
+    async def list_active(self, tenant_id: UUID) -> list[Vehicle]:
+        """Return all non-archived vehicles for a tenant."""
+        return [
+            self._row_to_vehicle(r)
+            for r in self._rows.values()
+            if r["tenant_id"] == tenant_id and not r.get("archived", False)
         ]

--- a/src/office_hero/services/schedule_suggestion_service.py
+++ b/src/office_hero/services/schedule_suggestion_service.py
@@ -1,0 +1,128 @@
+"""ScheduleSuggestionService — core of the Slice-13 routing MVP.
+
+Given a job and a time window, returns 2-3 ranked :class:`ScheduleOption`
+objects showing which vehicles are free and how long it would take each
+one to reach the job site.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+from office_hero.adapters.routing.protocol import RoutingAdapter
+from office_hero.core.exceptions import JobNotFoundError, SchedulingNotAvailableError
+
+
+@dataclass
+class ScheduleOption:
+    """A ranked appointment slot for one vehicle."""
+
+    vehicle_id: UUID
+    vehicle_display: str
+    suggested_start: datetime
+    travel_seconds: int
+    distance_meters: int
+    rank: int
+
+
+def _round_up_15(dt: datetime) -> datetime:
+    """Round *dt* up to the next 15-minute boundary (or return as-is if already on one)."""
+    minute = dt.minute
+    remainder = minute % 15
+    if remainder == 0 and dt.second == 0 and dt.microsecond == 0:
+        return dt
+    delta = timedelta(minutes=(15 - remainder), seconds=-dt.second, microseconds=-dt.microsecond)
+    return dt + delta
+
+
+class ScheduleSuggestionService:
+    """Produce ranked schedule suggestions for a job within a time window.
+
+    Depends on repository protocols (ADR 058) and a pluggable routing adapter.
+    All arguments are injected so unit tests can pass in-memory mocks.
+    """
+
+    def __init__(
+        self,
+        job_repo,
+        vehicle_repo,
+        routing_adapter: RoutingAdapter,
+        clock=None,
+    ) -> None:
+        self._job_repo = job_repo
+        self._vehicle_repo = vehicle_repo
+        self._routing = routing_adapter
+        self._clock = clock or (lambda: datetime.now(UTC))
+
+    async def get_options(
+        self,
+        tenant_id: UUID,
+        job_id: UUID,
+        *,
+        window_start: datetime,
+        window_end: datetime,
+        max_results: int = 3,
+    ) -> list[ScheduleOption]:
+        """Return up to *max_results* ranked options, sorted by travel time ASC.
+
+        Raises:
+            JobNotFoundError: if the job does not exist within *tenant_id*.
+            SchedulingNotAvailableError: if the job location has no geocoords.
+        """
+        job = await self._job_repo.get_by_id(job_id, tenant_id)
+        if job is None:
+            raise JobNotFoundError(f"Job {job_id} not found")
+
+        location = job.location
+        if location is None or location.lat is None or location.lng is None:
+            raise SchedulingNotAvailableError("Job location has not been geocoded yet.")
+
+        job_lat = float(location.lat)
+        job_lng = float(location.lng)
+
+        vehicles = await self._vehicle_repo.list_active(tenant_id)
+
+        candidates: list[tuple[int, int, object]] = []
+
+        for vehicle in vehicles:
+            busy_jobs = await self._job_repo.list_by_vehicle_in_window(
+                tenant_id, vehicle.id, window_start, window_end
+            )
+            if busy_jobs:
+                continue
+
+            from_lat = float(vehicle.home_base_lat) if vehicle.home_base_lat is not None else 0.0
+            from_lng = float(vehicle.home_base_lng) if vehicle.home_base_lng is not None else 0.0
+
+            route = await self._routing.get_route(from_lat, from_lng, job_lat, job_lng)
+            if route is None:
+                continue
+
+            candidates.append((route.duration_seconds, route.distance_meters, vehicle))
+
+        candidates.sort(key=lambda t: t[0])
+
+        options: list[ScheduleOption] = []
+        for rank, (duration_s, distance_m, vehicle) in enumerate(candidates[:max_results], start=1):
+            arrival = window_start + timedelta(seconds=duration_s)
+            suggested_start = _round_up_15(arrival)
+
+            if vehicle.nickname:
+                display = f"{vehicle.nickname} ({vehicle.license_plate})"
+            else:
+                display = vehicle.license_plate
+
+            options.append(
+                ScheduleOption(
+                    vehicle_id=vehicle.id,
+                    vehicle_display=display,
+                    suggested_start=suggested_start,
+                    travel_seconds=duration_s,
+                    distance_meters=distance_m,
+                    rank=rank,
+                )
+            )
+
+        return options

--- a/tests/api/test_schedule_options_api.py
+++ b/tests/api/test_schedule_options_api.py
@@ -108,9 +108,13 @@ def schedule_service(j_repo, v_repo):
 
 @pytest.fixture()
 def app(schedule_service) -> FastAPI:
+    saved = dict(limiter._route_limits)
+    limiter._route_limits.clear()
     a = create_app(schedule_suggestion_service=schedule_service)
     a.add_middleware(_ScheduleTestAuthMiddleware)
-    return a
+    yield a
+    limiter._route_limits.clear()
+    limiter._route_limits.update(saved)
 
 
 @pytest.fixture()

--- a/tests/api/test_schedule_options_api.py
+++ b/tests/api/test_schedule_options_api.py
@@ -1,0 +1,384 @@
+"""HTTP-layer tests for POST /jobs/{job_id}/schedule-options."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from office_hero.adapters.routing.stub import StubRoutingAdapter
+from office_hero.api.app import create_app
+from office_hero.api.limiter import limiter
+from office_hero.repositories.job_repository import InMemoryJobRepository
+from office_hero.repositories.vehicle_repository import InMemoryVehicleRepository
+from office_hero.services.schedule_suggestion_service import ScheduleSuggestionService
+
+
+@dataclass
+class _FakeLocation:
+    """Minimal location stand-in so API tests stay off SQLAlchemy machinery."""
+
+    lat: Decimal | None
+    lng: Decimal | None
+    geocode_status: str = "complete"
+
+
+# ---------------------------------------------------------------------------
+# Auth middleware
+# ---------------------------------------------------------------------------
+
+
+class _ScheduleTestAuthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        request.state.tenant_id = request.headers.get("X-Test-Tenant-Id")
+        request.state.user_id = request.headers.get("X-Test-User-Id")
+        request.state.role = request.headers.get("X-Test-Role", "tenant_admin")
+        perms_raw = request.headers.get("X-Test-Permissions", "job:read,vehicle:read")
+        request.state.permissions = [p.strip() for p in perms_raw.split(",") if p.strip()]
+        return await call_next(request)
+
+
+def _reset_limiter() -> None:
+    import contextlib
+
+    limiter.reset()
+    storage = getattr(getattr(limiter, "limiter", None), "storage", None)
+    if storage and hasattr(storage, "reset"):
+        with contextlib.suppress(Exception):
+            storage.reset()
+
+
+def _auth_headers(tenant_id, user_id, *, perms="job:read,vehicle:read") -> dict[str, str]:
+    return {
+        "X-Test-Tenant-Id": str(tenant_id),
+        "X-Test-User-Id": str(user_id),
+        "X-Test-Role": "tenant_admin",
+        "X-Test-Permissions": perms,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter():
+    _reset_limiter()
+    yield
+    _reset_limiter()
+
+
+@pytest.fixture()
+def tenant_id():
+    return uuid4()
+
+
+@pytest.fixture()
+def user_id():
+    return uuid4()
+
+
+@pytest.fixture()
+def j_repo():
+    return InMemoryJobRepository()
+
+
+@pytest.fixture()
+def v_repo():
+    return InMemoryVehicleRepository()
+
+
+@pytest.fixture()
+def schedule_service(j_repo, v_repo):
+    return ScheduleSuggestionService(
+        job_repo=j_repo,
+        vehicle_repo=v_repo,
+        routing_adapter=StubRoutingAdapter(),
+    )
+
+
+@pytest.fixture()
+def app(schedule_service) -> FastAPI:
+    a = create_app(schedule_suggestion_service=schedule_service)
+    a.add_middleware(_ScheduleTestAuthMiddleware)
+    return a
+
+
+@pytest.fixture()
+def client(app) -> Iterator[TestClient]:
+    with TestClient(app) as c:
+        yield c
+
+
+def _make_geocoded_location(tenant_id) -> _FakeLocation:
+    return _FakeLocation(lat=Decimal("41.8781"), lng=Decimal("-87.6298"))
+
+
+def _make_ungeocode_location(tenant_id) -> _FakeLocation:
+    return _FakeLocation(lat=None, lng=None, geocode_status="pending")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_missing_permissions_returns_403(client, tenant_id, user_id):
+    """Request without required permissions gets 403."""
+    resp = client.post(
+        f"/jobs/{uuid4()}/schedule-options",
+        json={
+            "window_start": "2026-06-01T09:00:00Z",
+            "window_end": "2026-06-01T17:00:00Z",
+        },
+        headers=_auth_headers(tenant_id, user_id, perms=""),
+    )
+    assert resp.status_code == 403
+
+
+def test_missing_vehicle_read_returns_403(client, tenant_id, user_id):
+    """Only job:read but not vehicle:read → 403."""
+    resp = client.post(
+        f"/jobs/{uuid4()}/schedule-options",
+        json={
+            "window_start": "2026-06-01T09:00:00Z",
+            "window_end": "2026-06-01T17:00:00Z",
+        },
+        headers=_auth_headers(tenant_id, user_id, perms="job:read"),
+    )
+    assert resp.status_code == 403
+
+
+def test_unknown_job_returns_404(client, tenant_id, user_id):
+    """Non-existent job_id → 404."""
+    resp = client.post(
+        f"/jobs/{uuid4()}/schedule-options",
+        json={
+            "window_start": "2026-06-01T09:00:00Z",
+            "window_end": "2026-06-01T17:00:00Z",
+        },
+        headers=_auth_headers(tenant_id, user_id),
+    )
+    assert resp.status_code == 404
+
+
+def test_ungeocoded_job_returns_422(client, j_repo, tenant_id, user_id):
+    """Job with no geocoords → 422."""
+    jid = uuid4()
+    now = datetime.now(UTC)
+    j_repo._rows[jid] = {
+        "id": jid,
+        "tenant_id": tenant_id,
+        "customer_id": uuid4(),
+        "location_id": uuid4(),
+        "industry": "plumbing",
+        "title": "Fix leak",
+        "description": None,
+        "status": "pending",
+        "priority": 50,
+        "service_type": None,
+        "requested_at": None,
+        "requested_until": None,
+        "estimated_duration_min": 60,
+        "scheduled_for": None,
+        "started_at": None,
+        "completed_at": None,
+        "cancelled_at": None,
+        "cancel_reason": None,
+        "custom_fields": {},
+        "external_id": None,
+        "assigned_vehicle_id": None,
+        "created_by_user_id": user_id,
+        "created_at": now,
+        "updated_at": now,
+    }
+    raw_job = j_repo._row_to_job(j_repo._rows[jid])
+    raw_job.location = _make_ungeocode_location(tenant_id)
+    j_repo._rows[jid]["_job_obj"] = raw_job
+
+    # Monkey-patch get_by_id to return our job with ungeocode location
+    original_get = j_repo.get_by_id
+
+    async def _patched_get(job_id, t_id):
+        if job_id == jid and t_id == tenant_id:
+            return raw_job
+        return await original_get(job_id, t_id)
+
+    j_repo.get_by_id = _patched_get
+
+    resp = client.post(
+        f"/jobs/{jid}/schedule-options",
+        json={
+            "window_start": "2026-06-01T09:00:00Z",
+            "window_end": "2026-06-01T17:00:00Z",
+        },
+        headers=_auth_headers(tenant_id, user_id),
+    )
+    assert resp.status_code == 422
+    assert "geocoded" in resp.json()["detail"].lower()
+
+
+def test_happy_path_returns_options(client, j_repo, v_repo, tenant_id, user_id):
+    """Happy path: 1 vehicle + geocoded job → 1 option with expected shape."""
+
+    async def _setup():
+        await v_repo.create(
+            tenant_id,
+            license_plate="HAPPY-001",
+            nickname="Blue Van",
+            home_base_lat=41.8,
+            home_base_lng=-87.6,
+        )
+
+        jid = uuid4()
+        now = datetime.now(UTC)
+        j_repo._rows[jid] = {
+            "id": jid,
+            "tenant_id": tenant_id,
+            "customer_id": uuid4(),
+            "location_id": uuid4(),
+            "industry": "plumbing",
+            "title": "Fix leak",
+            "description": None,
+            "status": "pending",
+            "priority": 50,
+            "service_type": None,
+            "requested_at": None,
+            "requested_until": None,
+            "estimated_duration_min": 60,
+            "scheduled_for": None,
+            "started_at": None,
+            "completed_at": None,
+            "cancelled_at": None,
+            "cancel_reason": None,
+            "custom_fields": {},
+            "external_id": None,
+            "assigned_vehicle_id": None,
+            "created_by_user_id": user_id,
+            "created_at": now,
+            "updated_at": now,
+        }
+        raw_job = j_repo._row_to_job(j_repo._rows[jid])
+        raw_job.location = _make_geocoded_location(tenant_id)
+
+        original_get = j_repo.get_by_id
+
+        async def _patched_get(job_id, t_id):
+            if job_id == jid and t_id == tenant_id:
+                return raw_job
+            return await original_get(job_id, t_id)
+
+        j_repo.get_by_id = _patched_get
+        return jid
+
+    jid = asyncio.get_event_loop().run_until_complete(_setup())
+
+    resp = client.post(
+        f"/jobs/{jid}/schedule-options",
+        json={
+            "window_start": "2026-06-01T09:00:00Z",
+            "window_end": "2026-06-01T17:00:00Z",
+        },
+        headers=_auth_headers(tenant_id, user_id),
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["job_id"] == str(jid)
+    assert len(body["options"]) == 1
+    opt = body["options"][0]
+    assert opt["rank"] == 1
+    assert opt["vehicle_display"] == "Blue Van (HAPPY-001)"
+    assert opt["travel_seconds"] == 900
+    assert opt["distance_meters"] == 12_000
+
+
+def test_no_vehicles_returns_empty_options(client, j_repo, tenant_id, user_id):
+    """No vehicles → empty options list, still 200."""
+
+    async def _setup():
+        jid = uuid4()
+        now = datetime.now(UTC)
+        j_repo._rows[jid] = {
+            "id": jid,
+            "tenant_id": tenant_id,
+            "customer_id": uuid4(),
+            "location_id": uuid4(),
+            "industry": "plumbing",
+            "title": "No vehicles",
+            "description": None,
+            "status": "pending",
+            "priority": 50,
+            "service_type": None,
+            "requested_at": None,
+            "requested_until": None,
+            "estimated_duration_min": 60,
+            "scheduled_for": None,
+            "started_at": None,
+            "completed_at": None,
+            "cancelled_at": None,
+            "cancel_reason": None,
+            "custom_fields": {},
+            "external_id": None,
+            "assigned_vehicle_id": None,
+            "created_by_user_id": user_id,
+            "created_at": now,
+            "updated_at": now,
+        }
+        raw_job = j_repo._row_to_job(j_repo._rows[jid])
+        raw_job.location = _make_geocoded_location(tenant_id)
+
+        original_get = j_repo.get_by_id
+
+        async def _patched_get(job_id, t_id):
+            if job_id == jid and t_id == tenant_id:
+                return raw_job
+            return await original_get(job_id, t_id)
+
+        j_repo.get_by_id = _patched_get
+        return jid
+
+    jid = asyncio.get_event_loop().run_until_complete(_setup())
+
+    resp = client.post(
+        f"/jobs/{jid}/schedule-options",
+        json={
+            "window_start": "2026-06-01T09:00:00Z",
+            "window_end": "2026-06-01T17:00:00Z",
+        },
+        headers=_auth_headers(tenant_id, user_id),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["options"] == []
+
+
+def test_invalid_request_body_returns_422(client, tenant_id, user_id):
+    """Missing window_start field → 422 from Pydantic."""
+    resp = client.post(
+        f"/jobs/{uuid4()}/schedule-options",
+        json={"window_end": "2026-06-01T17:00:00Z"},
+        headers=_auth_headers(tenant_id, user_id),
+    )
+    assert resp.status_code == 422
+
+
+def test_extra_fields_in_body_rejected(client, tenant_id, user_id):
+    """extra='forbid' means unknown request body fields → 422."""
+    resp = client.post(
+        f"/jobs/{uuid4()}/schedule-options",
+        json={
+            "window_start": "2026-06-01T09:00:00Z",
+            "window_end": "2026-06-01T17:00:00Z",
+            "unknown_field": "oops",
+        },
+        headers=_auth_headers(tenant_id, user_id),
+    )
+    assert resp.status_code == 422

--- a/tests/unit/test_schedule_suggestion_service.py
+++ b/tests/unit/test_schedule_suggestion_service.py
@@ -1,0 +1,262 @@
+"""Unit tests for ScheduleSuggestionService (TDD-first, no DB)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+
+from office_hero.adapters.routing.protocol import RouteResult
+from office_hero.adapters.routing.stub import StubRoutingAdapter
+from office_hero.core.exceptions import JobNotFoundError, SchedulingNotAvailableError
+from office_hero.repositories.job_repository import InMemoryJobRepository
+from office_hero.repositories.vehicle_repository import InMemoryVehicleRepository
+from office_hero.services.schedule_suggestion_service import ScheduleSuggestionService
+
+
+@dataclass
+class _FakeLocation:
+    """Minimal location stand-in so unit tests stay off SQLAlchemy machinery."""
+
+    lat: Decimal | None
+    lng: Decimal | None
+    geocode_status: str = "complete"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def tenant_id():
+    return uuid4()
+
+
+@pytest.fixture()
+def user_id():
+    return uuid4()
+
+
+@pytest.fixture()
+def j_repo():
+    return InMemoryJobRepository()
+
+
+@pytest.fixture()
+def v_repo():
+    return InMemoryVehicleRepository()
+
+
+@pytest.fixture()
+def routing():
+    return StubRoutingAdapter()
+
+
+@pytest.fixture()
+def service(j_repo, v_repo, routing):
+    return ScheduleSuggestionService(
+        job_repo=j_repo,
+        vehicle_repo=v_repo,
+        routing_adapter=routing,
+    )
+
+
+def _window():
+    start = datetime(2026, 6, 1, 9, 0, tzinfo=UTC)
+    end = datetime(2026, 6, 1, 17, 0, tzinfo=UTC)
+    return start, end
+
+
+def _make_location(*, lat=None, lng=None, geocode_status="complete") -> _FakeLocation:
+    from decimal import Decimal
+
+    return _FakeLocation(
+        lat=Decimal(str(lat)) if lat is not None else None,
+        lng=Decimal(str(lng)) if lng is not None else None,
+        geocode_status=geocode_status,
+    )
+
+
+async def _make_job(j_repo, tenant_id, user_id, *, location=None):
+    """Create a job and patch get_by_id so the service sees the right location."""
+    job = await j_repo.create(
+        tenant_id,
+        customer_id=uuid4(),
+        location_id=uuid4(),
+        industry="plumbing",
+        title="Fix leak",
+        created_by_user_id=user_id,
+    )
+    loc = location if location is not None else _make_location(lat=41.8781, lng=-87.6298)
+
+    original_get = j_repo.get_by_id
+    jid = job.id
+
+    async def _patched_get(job_id, t_id):
+        result = await original_get(job_id, t_id)
+        if result is not None and result.id == jid:
+            result.location = loc
+        return result
+
+    j_repo.get_by_id = _patched_get
+    return job
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_job_not_found_raises(service, tenant_id):
+    """get_options raises JobNotFoundError for an unknown job."""
+    start, end = _window()
+    with pytest.raises(JobNotFoundError):
+        await service.get_options(tenant_id, uuid4(), window_start=start, window_end=end)
+
+
+async def test_location_not_geocoded_raises(service, j_repo, tenant_id, user_id):
+    """get_options raises SchedulingNotAvailableError when coords are absent."""
+    job = await _make_job(j_repo, tenant_id, user_id, location=_make_location(lat=None, lng=None))
+    start, end = _window()
+    with pytest.raises(SchedulingNotAvailableError, match="not been geocoded"):
+        await service.get_options(tenant_id, job.id, window_start=start, window_end=end)
+
+
+async def test_no_vehicles_returns_empty(service, j_repo, tenant_id, user_id):
+    """get_options returns [] when no vehicles exist."""
+    job = await _make_job(j_repo, tenant_id, user_id)
+    start, end = _window()
+    result = await service.get_options(tenant_id, job.id, window_start=start, window_end=end)
+    assert result == []
+
+
+async def test_all_vehicles_busy_returns_empty(service, j_repo, v_repo, tenant_id, user_id):
+    """get_options returns [] when every vehicle is busy in the window."""
+    vehicle = await v_repo.create(
+        tenant_id,
+        license_plate="BUSY-001",
+        home_base_lat=41.8,
+        home_base_lng=-87.6,
+    )
+    job = await _make_job(j_repo, tenant_id, user_id)
+
+    # Create a conflicting job assigned to the vehicle
+    start, end = _window()
+    blocking_job = await j_repo.create(
+        tenant_id,
+        customer_id=uuid4(),
+        location_id=uuid4(),
+        industry="plumbing",
+        title="Blocking job",
+        created_by_user_id=user_id,
+    )
+    # Manually assign and schedule so it overlaps
+    blocking_job_row = j_repo._rows[blocking_job.id]
+    blocking_job_row["assigned_vehicle_id"] = vehicle.id
+    blocking_job_row["status"] = "scheduled"
+    blocking_job_row["scheduled_for"] = start + timedelta(hours=1)
+    blocking_job_row["estimated_duration_min"] = 120
+
+    result = await service.get_options(tenant_id, job.id, window_start=start, window_end=end)
+    assert result == []
+
+
+async def test_two_free_vehicles_sorted_by_travel_time(j_repo, v_repo, tenant_id, user_id):
+    """Two free vehicles → 2 options sorted by travel_seconds ASC."""
+
+    class _VariableRouter:
+        """Returns different times per vehicle to test sorting."""
+
+        def __init__(self):
+            self._calls: list[tuple[float, float, float, float]] = []
+
+        async def get_route(self, from_lat, from_lng, to_lat, to_lng):
+            self._calls.append((from_lat, from_lng, to_lat, to_lng))
+            # Use from_lat as a proxy: higher lat → longer trip
+            duration = 600 if from_lat < 40.0 else 1200
+            return RouteResult(duration_seconds=duration, distance_meters=duration * 10)
+
+    router = _VariableRouter()
+    svc = ScheduleSuggestionService(
+        job_repo=j_repo,
+        vehicle_repo=v_repo,
+        routing_adapter=router,
+    )
+
+    # vehicle A: lat 39 → 600 s (closer)
+    await v_repo.create(
+        tenant_id,
+        license_plate="CLOSE-001",
+        nickname="Close Van",
+        home_base_lat=39.0,
+        home_base_lng=-87.0,
+    )
+    # vehicle B: lat 41 → 1200 s (farther)
+    await v_repo.create(
+        tenant_id,
+        license_plate="FAR-002",
+        home_base_lat=41.0,
+        home_base_lng=-87.0,
+    )
+
+    job = await _make_job(j_repo, tenant_id, user_id)
+    start, end = _window()
+
+    options = await svc.get_options(tenant_id, job.id, window_start=start, window_end=end)
+
+    assert len(options) == 2
+    assert options[0].travel_seconds < options[1].travel_seconds
+    assert options[0].rank == 1
+    assert options[1].rank == 2
+    assert options[0].vehicle_display == "Close Van (CLOSE-001)"
+    assert options[1].vehicle_display == "FAR-002"
+
+
+async def test_max_results_caps_output(j_repo, v_repo, tenant_id, user_id):
+    """max_results=1 caps output at 1 even if 3 vehicles are free."""
+    for i in range(3):
+        await v_repo.create(
+            tenant_id,
+            license_plate=f"MULTI-{i:03d}",
+            home_base_lat=40.0 + i,
+            home_base_lng=-87.0,
+        )
+    job = await _make_job(j_repo, tenant_id, user_id)
+    start, end = _window()
+    svc = ScheduleSuggestionService(
+        job_repo=j_repo,
+        vehicle_repo=v_repo,
+        routing_adapter=StubRoutingAdapter(),
+    )
+    options = await svc.get_options(
+        tenant_id, job.id, window_start=start, window_end=end, max_results=1
+    )
+    assert len(options) == 1
+
+
+async def test_suggested_start_rounded_to_15_minutes(j_repo, v_repo, tenant_id, user_id):
+    """suggested_start is rounded up to the next 15-minute boundary."""
+
+    class _OddRouter:
+        async def get_route(self, from_lat, from_lng, to_lat, to_lng):
+            return RouteResult(duration_seconds=600, distance_meters=5000)
+
+    svc = ScheduleSuggestionService(
+        job_repo=j_repo,
+        vehicle_repo=v_repo,
+        routing_adapter=_OddRouter(),
+    )
+    await v_repo.create(tenant_id, license_plate="ROUND-001")
+    job = await _make_job(j_repo, tenant_id, user_id)
+
+    # window_start at 09:07 → arrival at 09:17 → round to 09:30
+    start = datetime(2026, 6, 1, 9, 7, tzinfo=UTC)
+    end = datetime(2026, 6, 1, 17, 0, tzinfo=UTC)
+    options = await svc.get_options(tenant_id, job.id, window_start=start, window_end=end)
+
+    assert len(options) == 1
+    assert options[0].suggested_start.minute == 30


### PR DESCRIPTION
## Summary

- Adds ORS routing adapter (`adapters/routing/`) with stub (tests + no-API-key fallback), live ORS implementation, and factory — mirrors the existing geocoding adapter pattern
- Adds `ScheduleSuggestionService`: given a job + time window, returns up to 3 ranked appointment slots by fetching free vehicles, calling the routing adapter, sorting by travel time, and rounding suggested start to 15-min boundaries
- Adds `POST /jobs/{job_id}/schedule-options` with dual RBAC (`job:read` + `vehicle:read`), 60/min rate limit, and Pydantic v2 schemas
- Migration `0007_job_vehicle_assignment`: `assigned_vehicle_id` nullable FK on `jobs` + index; `SchedulingNotAvailableError` and `RoutingError` (→ 503) added to exception hierarchy

## Test plan

- [x] `tests/unit/test_schedule_suggestion_service.py` — 7 unit tests
- [x] `tests/api/test_schedule_options_api.py` — 8 API tests
- [x] Rate-limit accumulation fix applied to all test fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)