### PR TITLE
feat(dispatch): suggested routes create real Routes; manual override UI + Routes page

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,11 +18,15 @@ repos:
         args: [--line-length=100]
 
   # CVE scanning on push only (slow; skip with SKIP=pip-audit)
+  # Ignores (no upstream fix available — re-check periodically):
+  #   CVE-2024-23342  ecdsa Minerva timing side-channel; maintainers consider
+  #                   side channels out of scope, no planned fix. Transitive
+  #                   via python-jose; we only verify signatures server-side.
   - repo: local
     hooks:
       - id: pip-audit
         name: pip-audit dependency scan
-        entry: bash -c 'poetry run pip-audit --desc'
+        entry: bash -c 'poetry run pip-audit --desc --ignore-vuln CVE-2024-23342'
         language: system
         pass_filenames: false
         always_run: true

--- a/apps/admin-web/src/App.tsx
+++ b/apps/admin-web/src/App.tsx
@@ -5,6 +5,7 @@ import { LoginPage } from './components/LoginPage';
 import { NavShell } from './components/NavShell';
 import { JobsPage } from './pages/JobsPage';
 import { ContractsPage } from './pages/ContractsPage';
+import { RoutesPage } from './pages/RoutesPage';
 import { DispatchPage } from './pages/DispatchPage';
 import { VehiclesPage } from './pages/VehiclesPage';
 import { UsersPage } from './pages/UsersPage';
@@ -34,6 +35,7 @@ const AppContent: React.FC = () => {
           <Route path="/" element={<JobsPage />} />
           <Route path="/jobs" element={<JobsPage />} />
           <Route path="/contracts" element={<ContractsPage />} />
+          <Route path="/routes" element={<RoutesPage />} />
           <Route path="/dispatch" element={<DispatchPage />} />
           <Route path="/vehicles" element={<VehiclesPage />} />
           <Route path="/users" element={<UsersPage />} />

--- a/apps/admin-web/src/__tests__/RoutesPage.test.tsx
+++ b/apps/admin-web/src/__tests__/RoutesPage.test.tsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const mockListRoutesApi = jest.fn();
+const mockResequenceRouteApi = jest.fn();
+const mockStartRouteApi = jest.fn();
+const mockCancelRouteApi = jest.fn();
+const mockListVehicles = jest.fn();
+
+jest.mock('../api', () => ({
+  listRoutesApi: (...args: unknown[]) => mockListRoutesApi(...args),
+  resequenceRouteApi: (...args: unknown[]) => mockResequenceRouteApi(...args),
+  startRouteApi: (...args: unknown[]) => mockStartRouteApi(...args),
+  cancelRouteApi: (...args: unknown[]) => mockCancelRouteApi(...args),
+}));
+
+jest.mock('@office-hero/api-client', () => ({
+  listVehicles: (...args: unknown[]) => mockListVehicles(...args),
+}));
+
+import { RoutesPage } from '../pages/RoutesPage';
+
+const buildStop = (overrides: Record<string, unknown> = {}) => ({
+  id: 'stop-1',
+  route_id: 'route-1',
+  job_id: 'job-1',
+  sequence_index: 0,
+  status: 'pending',
+  planned_eta: null,
+  actual_arrived_at: null,
+  actual_completed_at: null,
+  planned_distance_from_prev_m: 0,
+  planned_duration_from_prev_s: 0,
+  ...overrides,
+});
+
+const buildRoute = (overrides: Record<string, unknown> = {}) => ({
+  id: 'route-1',
+  tenant_id: 'tenant-1',
+  vehicle_id: 'veh-1',
+  vehicle_crew_id: 'crew-1',
+  work_date: '2026-06-12',
+  status: 'committed',
+  committed_at: '2026-06-12T08:00:00Z',
+  started_at: null,
+  completed_at: null,
+  cancelled_at: null,
+  cancel_reason: null,
+  total_distance_m: 12000,
+  total_duration_s: 900,
+  option_kind_applied: 'suggested',
+  notes: null,
+  stops: [
+    buildStop(),
+    buildStop({ id: 'stop-2', job_id: 'job-2', sequence_index: 1 }),
+  ],
+  ...overrides,
+});
+
+describe('RoutesPage', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockListVehicles.mockResolvedValue([
+      { id: 'veh-1', name: 'Van #1', license_plate: 'ABC-123' },
+    ]);
+  });
+
+  it('renders route cards with vehicle name, status, and ordered stops', async () => {
+    mockListRoutesApi.mockResolvedValue({ items: [buildRoute()], total: 1 });
+
+    render(<RoutesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('route-card')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Van #1')).toBeInTheDocument();
+    expect(screen.getByText('Committed')).toBeInTheDocument();
+    expect(screen.getAllByTestId('route-stop')).toHaveLength(2);
+  });
+
+  it('shows empty state when no routes for the date', async () => {
+    mockListRoutesApi.mockResolvedValue({ items: [], total: 0 });
+
+    render(<RoutesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No routes for this date/i)).toBeInTheDocument();
+    });
+  });
+
+  it('reorders stops locally and saves via resequence API', async () => {
+    mockListRoutesApi.mockResolvedValue({ items: [buildRoute()], total: 1 });
+    mockResequenceRouteApi.mockResolvedValue(
+      buildRoute({
+        stops: [
+          buildStop({ id: 'stop-2', job_id: 'job-2', sequence_index: 0 }),
+          buildStop({ id: 'stop-1', job_id: 'job-1', sequence_index: 1 }),
+        ],
+      }),
+    );
+
+    render(<RoutesPage />);
+    await waitFor(() => screen.getByTestId('route-card'));
+
+    fireEvent.click(screen.getByRole('button', { name: /Move stop 1 down/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Save new order/i }));
+
+    await waitFor(() => {
+      expect(mockResequenceRouteApi).toHaveBeenCalledWith('route-1', ['job-2', 'job-1']);
+    });
+  });
+
+  it('starts a committed route', async () => {
+    mockListRoutesApi.mockResolvedValue({ items: [buildRoute()], total: 1 });
+    mockStartRouteApi.mockResolvedValue(buildRoute({ status: 'in_progress' }));
+
+    render(<RoutesPage />);
+    await waitFor(() => screen.getByTestId('route-card'));
+
+    fireEvent.click(screen.getByRole('button', { name: /Start route/i }));
+
+    await waitFor(() => {
+      expect(mockStartRouteApi).toHaveBeenCalledWith('route-1');
+      expect(screen.getByText('In Progress')).toBeInTheDocument();
+    });
+  });
+
+  it('cancels a route with a reason', async () => {
+    mockListRoutesApi.mockResolvedValue({ items: [buildRoute()], total: 1 });
+    mockCancelRouteApi.mockResolvedValue(
+      buildRoute({ status: 'cancelled', cancel_reason: 'Tech sick' }),
+    );
+
+    render(<RoutesPage />);
+    await waitFor(() => screen.getByTestId('route-card'));
+
+    fireEvent.click(screen.getByRole('button', { name: /^Cancel$/i }));
+    fireEvent.change(screen.getByLabelText(/Reason/i), { target: { value: 'Tech sick' } });
+    fireEvent.click(screen.getByRole('button', { name: /Cancel route/i }));
+
+    await waitFor(() => {
+      expect(mockCancelRouteApi).toHaveBeenCalledWith('route-1', 'Tech sick');
+      expect(screen.getByText('Cancelled')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error alert on load failure', async () => {
+    mockListRoutesApi.mockRejectedValue({ status: 500, detail: 'boom' });
+
+    render(<RoutesPage />);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('boom');
+  });
+});

--- a/apps/admin-web/src/api.ts
+++ b/apps/admin-web/src/api.ts
@@ -274,6 +274,8 @@ export function getScheduleOptionsApi(
 export interface DispatchRequest {
   vehicle_id: string;
   scheduled_for: string;
+  travel_seconds?: number;
+  distance_meters?: number;
 }
 
 export interface DispatchResponse {
@@ -284,6 +286,7 @@ export interface DispatchResponse {
   title: string;
   customer_id: string;
   location_id: string;
+  route_id: string | null;
 }
 
 export function dispatchJobApi(
@@ -293,6 +296,79 @@ export function dispatchJobApi(
   return request<DispatchResponse>(`/jobs/${jobId}/dispatch`, {
     method: 'POST',
     body: JSON.stringify(body),
+  });
+}
+
+// --- Route types (Slice 14) ---
+
+export type RouteStatus = 'draft' | 'committed' | 'in_progress' | 'complete' | 'cancelled';
+export type RouteStopStatus = 'pending' | 'arrived' | 'complete' | 'skipped';
+
+export interface RouteStopRead {
+  id: string;
+  route_id: string;
+  job_id: string;
+  sequence_index: number;
+  status: RouteStopStatus;
+  planned_eta: string | null;
+  actual_arrived_at: string | null;
+  actual_completed_at: string | null;
+  planned_distance_from_prev_m: number;
+  planned_duration_from_prev_s: number;
+}
+
+export interface RouteRead {
+  id: string;
+  tenant_id: string;
+  vehicle_id: string;
+  vehicle_crew_id: string;
+  work_date: string;
+  status: RouteStatus;
+  committed_at: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  cancelled_at: string | null;
+  cancel_reason: string | null;
+  total_distance_m: number;
+  total_duration_s: number;
+  option_kind_applied: string | null;
+  notes: string | null;
+  stops: RouteStopRead[];
+}
+
+export interface RouteListResponse {
+  items: RouteRead[];
+  total: number;
+}
+
+// --- Route API functions ---
+
+export function listRoutesApi(date: string): Promise<RouteListResponse> {
+  return request<RouteListResponse>(`/routes?date=${encodeURIComponent(date)}`);
+}
+
+export function getRouteApi(routeId: string): Promise<RouteRead> {
+  return request<RouteRead>(`/routes/${routeId}`);
+}
+
+export function resequenceRouteApi(
+  routeId: string,
+  jobIds: string[],
+): Promise<RouteRead> {
+  return request<RouteRead>(`/routes/${routeId}/resequence`, {
+    method: 'POST',
+    body: JSON.stringify({ job_ids: jobIds }),
+  });
+}
+
+export function startRouteApi(routeId: string): Promise<RouteRead> {
+  return request<RouteRead>(`/routes/${routeId}/start`, { method: 'POST' });
+}
+
+export function cancelRouteApi(routeId: string, reason: string): Promise<RouteRead> {
+  return request<RouteRead>(`/routes/${routeId}/cancel`, {
+    method: 'POST',
+    body: JSON.stringify({ reason }),
   });
 }
 

--- a/apps/admin-web/src/components/NavShell.tsx
+++ b/apps/admin-web/src/components/NavShell.tsx
@@ -6,6 +6,7 @@ import { Button } from './ui/Button';
 const navItems = [
   { to: '/jobs',      label: 'Jobs'      },
   { to: '/contracts', label: 'Contracts' },
+  { to: '/routes',    label: 'Routes'    },
   { to: '/dispatch',  label: 'Dispatch'  },
   { to: '/vehicles',  label: 'Vehicles'  },
   { to: '/users',     label: 'Users'     },

--- a/apps/admin-web/src/e2e/screenshots.spec.ts
+++ b/apps/admin-web/src/e2e/screenshots.spec.ts
@@ -28,6 +28,7 @@ const ROUTES: ReadonlyArray<{ name: string; path: string; auth: boolean }> = [
   { name: '05-users', path: '/users', auth: true },
   { name: '06-customers', path: '/customers', auth: true },
   { name: '07-contracts', path: '/contracts', auth: true },
+  { name: '08-routes', path: '/routes', auth: true },
 ];
 
 const SCREENSHOT_DIR = process.env.SCREENSHOT_DIR ?? 'screenshots';

--- a/apps/admin-web/src/pages/JobsPage.tsx
+++ b/apps/admin-web/src/pages/JobsPage.tsx
@@ -2,6 +2,8 @@ import React, { useCallback, useEffect, useState } from 'react';
 import {
   listCustomers,
   listLocations,
+  listVehicles,
+  type AdminVehicle,
   type CustomerSummary,
   type LocationRead,
 } from '@office-hero/api-client';
@@ -288,6 +290,26 @@ function ScheduleModal({
   const windowInvalid = windowEnd <= windowStart;
   const [dispatching, setDispatching] = useState(false);
   const [dispatchError, setDispatchError] = useState<string | null>(null);
+  // Manual override — the "fourth option": any vehicle, any time.
+  const [manualMode, setManualMode] = useState(false);
+  const [vehicles, setVehicles] = useState<AdminVehicle[]>([]);
+  const [manualVehicleId, setManualVehicleId] = useState('');
+  const [manualTime, setManualTime] = useState(() => tomorrowWindow().start);
+
+  useEffect(() => {
+    if (!manualMode || vehicles.length > 0) return;
+    let cancelled = false;
+    listVehicles()
+      .then((v) => {
+        if (!cancelled) setVehicles(v);
+      })
+      .catch(() => {
+        // Selection list is a convenience; dispatch validates server-side.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [manualMode, vehicles.length]);
 
   const fetchOptions = async () => {
     setLoadingOptions(true);
@@ -310,14 +332,22 @@ function ScheduleModal({
   };
 
   const handleDispatch = async () => {
-    if (!selectedOption) return;
+    const payload = manualMode
+      ? manualVehicleId && manualTime
+        ? { vehicle_id: manualVehicleId, scheduled_for: new Date(manualTime).toISOString() }
+        : null
+      : selectedOption
+        ? {
+            vehicle_id: selectedOption.vehicle_id,
+            scheduled_for: selectedOption.suggested_start,
+            travel_seconds: selectedOption.travel_seconds,
+          }
+        : null;
+    if (!payload) return;
     setDispatching(true);
     setDispatchError(null);
     try {
-      const result = await dispatchJobApi(job.id, {
-        vehicle_id: selectedOption.vehicle_id,
-        scheduled_for: selectedOption.suggested_start,
-      });
+      const result = await dispatchJobApi(job.id, payload);
       onDispatched(result);
     } catch (err) {
       const apiErr = err as ApiError;
@@ -326,6 +356,8 @@ function ScheduleModal({
       setDispatching(false);
     }
   };
+
+  const canConfirm = manualMode ? Boolean(manualVehicleId && manualTime) : Boolean(selectedOption);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
@@ -436,6 +468,57 @@ function ScheduleModal({
           </>
         )}
 
+        <div className="mb-4 border-t border-neutral-200 pt-3">
+          <label className="flex items-center gap-2 text-sm font-medium text-neutral-700">
+            <input
+              type="checkbox"
+              className="h-4 w-4 rounded border-neutral-300 text-blue-600 focus:ring-blue-500"
+              checked={manualMode}
+              onChange={(e) => setManualMode(e.target.checked)}
+            />
+            Assign manually instead (override suggestions)
+          </label>
+          {manualMode && (
+            <div className="mt-3 grid grid-cols-2 gap-3">
+              <div>
+                <label
+                  htmlFor="manual-vehicle"
+                  className="mb-1 block text-sm font-medium text-neutral-700"
+                >
+                  Vehicle
+                </label>
+                <select
+                  id="manual-vehicle"
+                  className="block w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                  value={manualVehicleId}
+                  onChange={(e) => setManualVehicleId(e.target.value)}
+                >
+                  <option value="">Select a vehicle…</option>
+                  {vehicles.map((v) => (
+                    <option key={v.id} value={v.id}>
+                      {v.name || v.license_plate || v.id.slice(0, 8)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label
+                  htmlFor="manual-time"
+                  className="mb-1 block text-sm font-medium text-neutral-700"
+                >
+                  Start time
+                </label>
+                <Input
+                  id="manual-time"
+                  type="datetime-local"
+                  value={manualTime}
+                  onChange={(e) => setManualTime(e.target.value)}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+
         {dispatchError && (
           <Alert variant="destructive" className="mb-4">
             {dispatchError}
@@ -448,7 +531,7 @@ function ScheduleModal({
           </Button>
           <Button
             type="button"
-            disabled={!selectedOption || dispatching}
+            disabled={!canConfirm || dispatching}
             onClick={() => void handleDispatch()}
           >
             {dispatching ? 'Booking…' : 'Confirm booking'}
@@ -530,6 +613,7 @@ export const JobsPage: React.FC = () => {
           onChange={(e) => setSearch(e.target.value)}
         />
         <select
+          aria-label="Filter by status"
           className="rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value as JobStatus | '')}

--- a/apps/admin-web/src/pages/RoutesPage.tsx
+++ b/apps/admin-web/src/pages/RoutesPage.tsx
@@ -1,0 +1,429 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { listVehicles, type AdminVehicle } from '@office-hero/api-client';
+import {
+  type ApiError,
+  type RouteRead,
+  type RouteStatus,
+  type RouteStopStatus,
+  cancelRouteApi,
+  listRoutesApi,
+  resequenceRouteApi,
+  startRouteApi,
+} from '../api';
+import { Alert } from '../components/ui/Alert';
+import { Button } from '../components/ui/Button';
+import { Card, CardContent, CardHeader } from '../components/ui/Card';
+import { Input } from '../components/ui/Input';
+import { Skeleton } from '../components/ui/Skeleton';
+
+const ROUTE_STATUS_COLORS: Record<RouteStatus, string> = {
+  draft:       'bg-neutral-100 text-neutral-600',
+  committed:   'bg-blue-100 text-blue-800',
+  in_progress: 'bg-indigo-100 text-indigo-800',
+  complete:    'bg-green-100 text-green-800',
+  cancelled:   'bg-neutral-100 text-neutral-500',
+};
+
+const ROUTE_STATUS_LABELS: Record<RouteStatus, string> = {
+  draft:       'Draft',
+  committed:   'Committed',
+  in_progress: 'In Progress',
+  complete:    'Complete',
+  cancelled:   'Cancelled',
+};
+
+const STOP_STATUS_COLORS: Record<RouteStopStatus, string> = {
+  pending:  'bg-amber-100 text-amber-800',
+  arrived:  'bg-indigo-100 text-indigo-800',
+  complete: 'bg-green-100 text-green-800',
+  skipped:  'bg-neutral-100 text-neutral-500',
+};
+
+function StatusBadge({ status }: { status: RouteStatus }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${ROUTE_STATUS_COLORS[status] ?? 'bg-neutral-100 text-neutral-600'}`}
+    >
+      {ROUTE_STATUS_LABELS[status] ?? status}
+    </span>
+  );
+}
+
+function todayISODate(): string {
+  const d = new Date();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${d.getFullYear()}-${month}-${day}`;
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds <= 0) return '—';
+  const m = Math.round(seconds / 60);
+  if (m < 60) return `${m} min`;
+  const h = Math.floor(m / 60);
+  const rem = m % 60;
+  return rem > 0 ? `${h}h ${rem}m` : `${h}h`;
+}
+
+function formatDistance(meters: number): string {
+  if (meters <= 0) return '—';
+  return meters >= 1000 ? `${(meters / 1000).toFixed(1)} km` : `${meters} m`;
+}
+
+function CancelRouteModal({
+  route,
+  onClose,
+  onCancelled,
+}: {
+  route: RouteRead;
+  onClose: () => void;
+  onCancelled: (route: RouteRead) => void;
+}) {
+  const [reason, setReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleCancel = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const cancelled = await cancelRouteApi(route.id, reason);
+      onCancelled(cancelled);
+    } catch (err) {
+      const apiErr = err as ApiError;
+      setError(apiErr?.detail ?? (err instanceof Error ? err.message : String(err)));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        <h2 className="mb-1 text-lg font-semibold text-neutral-900">Cancel route</h2>
+        <p className="mb-4 text-sm text-neutral-500">
+          All remaining stops will be skipped and their jobs returned to pending.
+        </p>
+        {error && (
+          <Alert variant="destructive" className="mb-4">
+            {error}
+          </Alert>
+        )}
+        <label htmlFor="cancel-reason" className="mb-1 block text-sm font-medium text-neutral-700">
+          Reason *
+        </label>
+        <Input
+          id="cancel-reason"
+          value={reason}
+          maxLength={512}
+          onChange={(e) => setReason(e.target.value)}
+          placeholder="e.g. Technician called in sick"
+        />
+        <div className="mt-4 flex justify-end gap-2">
+          <Button type="button" variant="ghost" onClick={onClose} disabled={submitting}>
+            Keep route
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={() => void handleCancel()}
+            disabled={submitting || reason.trim().length < 3}
+          >
+            {submitting ? 'Cancelling…' : 'Cancel route'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RouteCard({
+  route,
+  vehicleName,
+  onUpdated,
+  onError,
+}: {
+  route: RouteRead;
+  vehicleName: string;
+  onUpdated: (route: RouteRead) => void;
+  onError: (message: string) => void;
+}) {
+  // Local working order for the manual override; null = not editing.
+  const [order, setOrder] = useState<string[] | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [starting, setStarting] = useState(false);
+  const [showCancel, setShowCancel] = useState(false);
+
+  const stops = [...route.stops].sort((a, b) => a.sequence_index - b.sequence_index);
+  const displayedJobIds = order ?? stops.map((s) => s.job_id);
+  const byJobId = new Map(stops.map((s) => [s.job_id, s]));
+  const dirty = order !== null && order.join() !== stops.map((s) => s.job_id).join();
+
+  const move = (index: number, delta: number) => {
+    const next = [...displayedJobIds];
+    const target = index + delta;
+    if (target < 0 || target >= next.length) return;
+    [next[index], next[target]] = [next[target], next[index]];
+    setOrder(next);
+  };
+
+  const saveOrder = async () => {
+    if (!order) return;
+    setSaving(true);
+    try {
+      const updated = await resequenceRouteApi(route.id, order);
+      setOrder(null);
+      onUpdated(updated);
+    } catch (err) {
+      const apiErr = err as ApiError;
+      onError(apiErr?.detail ?? (err instanceof Error ? err.message : String(err)));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const start = async () => {
+    setStarting(true);
+    try {
+      onUpdated(await startRouteApi(route.id));
+    } catch (err) {
+      const apiErr = err as ApiError;
+      onError(apiErr?.detail ?? (err instanceof Error ? err.message : String(err)));
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  const reorderable = route.status === 'committed';
+
+  return (
+    <Card data-testid="route-card">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <div>
+          <div className="flex items-center gap-2">
+            <span className="font-semibold text-neutral-900">{vehicleName}</span>
+            <StatusBadge status={route.status} />
+          </div>
+          <p className="mt-0.5 text-sm text-neutral-500">
+            {stops.length} stop{stops.length === 1 ? '' : 's'} ·{' '}
+            {formatDuration(route.total_duration_s)} travel ·{' '}
+            {formatDistance(route.total_distance_m)}
+            {route.cancel_reason ? ` · ${route.cancel_reason}` : ''}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          {route.status === 'committed' && (
+            <>
+              <Button size="sm" onClick={() => void start()} disabled={starting || dirty}>
+                {starting ? 'Starting…' : 'Start route'}
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => setShowCancel(true)}>
+                Cancel
+              </Button>
+            </>
+          )}
+          {route.status === 'in_progress' && (
+            <Button size="sm" variant="ghost" onClick={() => setShowCancel(true)}>
+              Cancel
+            </Button>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        <ol className="space-y-1.5">
+          {displayedJobIds.map((jobId, i) => {
+            const stop = byJobId.get(jobId);
+            if (!stop) return null;
+            return (
+              <li
+                key={jobId}
+                data-testid="route-stop"
+                className="flex items-center justify-between rounded-md border border-neutral-200 px-3 py-2"
+              >
+                <div className="flex items-center gap-3">
+                  <span className="w-6 text-center text-sm font-semibold text-neutral-400">
+                    {i + 1}
+                  </span>
+                  <div>
+                    <span className="font-mono text-xs text-neutral-500">
+                      Job {jobId.slice(0, 8)}
+                    </span>
+                    <span
+                      className={`ml-2 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STOP_STATUS_COLORS[stop.status] ?? ''}`}
+                    >
+                      {stop.status}
+                    </span>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 text-sm text-neutral-500">
+                  {stop.planned_eta && (
+                    <span>
+                      {new Date(stop.planned_eta).toLocaleTimeString([], {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })}
+                    </span>
+                  )}
+                  {reorderable && (
+                    <span className="flex gap-1">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        aria-label={`Move stop ${i + 1} up`}
+                        disabled={i === 0 || saving}
+                        onClick={() => move(i, -1)}
+                      >
+                        ↑
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        aria-label={`Move stop ${i + 1} down`}
+                        disabled={i === displayedJobIds.length - 1 || saving}
+                        onClick={() => move(i, 1)}
+                      >
+                        ↓
+                      </Button>
+                    </span>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+        {dirty && (
+          <div className="mt-3 flex justify-end gap-2">
+            <Button size="sm" variant="ghost" onClick={() => setOrder(null)} disabled={saving}>
+              Discard order
+            </Button>
+            <Button size="sm" onClick={() => void saveOrder()} disabled={saving}>
+              {saving ? 'Saving…' : 'Save new order'}
+            </Button>
+          </div>
+        )}
+      </CardContent>
+      {showCancel && (
+        <CancelRouteModal
+          route={route}
+          onClose={() => setShowCancel(false)}
+          onCancelled={(cancelled) => {
+            setShowCancel(false);
+            onUpdated(cancelled);
+          }}
+        />
+      )}
+    </Card>
+  );
+}
+
+export const RoutesPage: React.FC = () => {
+  const [workDate, setWorkDate] = useState(() => todayISODate());
+  const [routes, setRoutes] = useState<RouteRead[]>([]);
+  const [vehicles, setVehicles] = useState<AdminVehicle[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    listVehicles()
+      .then((v) => {
+        if (!cancelled) setVehicles(v);
+      })
+      .catch(() => {
+        // Vehicle names are display sugar; IDs still render.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const load = useCallback(async (date: string) => {
+    setLoading(true);
+    try {
+      const data = await listRoutesApi(date);
+      setRoutes(data.items);
+      setError(null);
+    } catch (err) {
+      const apiErr = err as ApiError;
+      setError(apiErr?.detail ?? (err instanceof Error ? err.message : String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load(workDate);
+  }, [workDate, load]);
+
+  const vehicleName = (vehicleId: string): string => {
+    const v = vehicles.find((x) => x.id === vehicleId);
+    return v?.name || v?.license_plate || `Vehicle ${vehicleId.slice(0, 8)}`;
+  };
+
+  const replaceRoute = (updated: RouteRead) => {
+    setRoutes((prev) => prev.map((r) => (r.id === updated.id ? updated : r)));
+  };
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-neutral-900">Routes</h1>
+          {!loading && (
+            <p className="mt-0.5 text-sm text-neutral-500">
+              {routes.length} route{routes.length === 1 ? '' : 's'} on{' '}
+              {new Date(`${workDate}T00:00:00`).toLocaleDateString()}
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <label htmlFor="route-date" className="text-sm font-medium text-neutral-700">
+            Date
+          </label>
+          <Input
+            id="route-date"
+            type="date"
+            className="w-44"
+            value={workDate}
+            onChange={(e) => setWorkDate(e.target.value)}
+          />
+          <Button variant="outline" onClick={() => void load(workDate)} disabled={loading}>
+            Refresh
+          </Button>
+        </div>
+      </div>
+
+      {error && (
+        <Alert variant="destructive" className="mb-4">
+          {error}
+        </Alert>
+      )}
+
+      {loading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-28 w-full" />
+          ))}
+        </div>
+      ) : routes.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-neutral-300 py-12 text-center">
+          <p className="text-neutral-500">
+            No routes for this date. Dispatch a job from the Jobs page to create one.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {routes.map((route) => (
+            <RouteCard
+              key={route.id}
+              route={route}
+              vehicleName={vehicleName(route.vehicle_id)}
+              onUpdated={replaceRoute}
+              onError={setError}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-hero-mobile",
-  "version": "0.1.12",
+  "version": "0.1.14",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-hero-mobile",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-hero-mobile",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-hero-mobile",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-hero-mobile",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/poetry.lock
+++ b/poetry.lock
@@ -957,26 +957,26 @@ testing = ["hatch", "pre-commit", "pytest", "tox"]
 
 [[package]]
 name = "fastapi"
-version = "0.135.1"
+version = "0.136.3"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e"},
-    {file = "fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd"},
+    {file = "fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620"},
+    {file = "fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab"},
 ]
 
 [package.dependencies]
 annotated-doc = ">=0.0.2"
-pydantic = ">=2.7.0"
+pydantic = ">=2.9.0"
 starlette = ">=0.46.0"
 typing-extensions = ">=4.8.0"
 typing-inspection = ">=0.4.2"
 
 [package.extras]
 all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "pyyaml (>=5.3.1)", "uvicorn[standard] (>=0.12.0)"]
-standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
+standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "fastar (>=0.9.0)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
 standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[standard-no-fastapi-cloud-cli] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
 
 [[package]]
@@ -2041,14 +2041,14 @@ yaml = ["pyyaml (>=6.0.1)"]
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
-    {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
 ]
 
 [package.extras]
@@ -2089,14 +2089,14 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b"},
-    {file = "pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
@@ -2246,14 +2246,14 @@ test = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.32"
 description = "A streaming multipart parser for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
-    {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
+    {file = "python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23"},
+    {file = "python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e"},
 ]
 
 [[package]]
@@ -2444,25 +2444,25 @@ typing-extensions = {version = ">=4.4.0", markers = "python_version < \"3.13\""}
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.34.2"
 description = "Python HTTP for Humans."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"},
-    {file = "requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"},
+    {file = "requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"},
+    {file = "requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed"},
 ]
 
 [package.dependencies]
-certifi = ">=2017.4.17"
+certifi = ">=2023.5.7"
 charset_normalizer = ">=2,<4"
 idna = ">=2.5,<4"
-urllib3 = ">=1.21.1,<3"
+urllib3 = ">=1.26,<3"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<8)"]
 
 [[package]]
 name = "rich"
@@ -2820,14 +2820,14 @@ uvicorn = ["uvicorn (>=0.34.0)"]
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.3.1"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74"},
-    {file = "starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933"},
+    {file = "starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6"},
+    {file = "starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0"},
 ]
 
 [package.dependencies]
@@ -2835,7 +2835,7 @@ anyio = ">=3.6.2,<5"
 typing-extensions = {version = ">=4.10.0", markers = "python_version < \"3.13\""}
 
 [package.extras]
-full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
+full = ["httpx (>=0.27.0,<0.29.0)", "httpx2 (>=2.0.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
 
 [[package]]
 name = "stevedore"
@@ -2959,14 +2959,14 @@ typing-extensions = ">=4.12.0"
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
-    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1836,14 +1836,14 @@ defusedxml = ">=0.7.1,<0.8.0"
 
 [[package]]
 name = "pyasn1"
-version = "0.6.2"
+version = "0.6.3"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf"},
-    {file = "pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b"},
+    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
+    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
 ]
 
 [[package]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -748,75 +748,68 @@ toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
 name = "cryptography"
-version = "46.0.5"
+version = "48.0.1"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
-python-versions = "!=3.9.0,!=3.9.1,>=3.8"
+python-versions = "!=3.9.0,!=3.9.1,>=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:351695ada9ea9618b3500b490ad54c739860883df6c1f555e088eaf25b1bbaad"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731"},
-    {file = "cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82"},
-    {file = "cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1"},
-    {file = "cryptography-46.0.5-cp311-abi3-win32.whl", hash = "sha256:60ee7e19e95104d4c03871d7d7dfb3d22ef8a9b9c6778c94e1c8fcc8365afd48"},
-    {file = "cryptography-46.0.5-cp311-abi3-win_amd64.whl", hash = "sha256:38946c54b16c885c72c4f59846be9743d699eee2b69b6988e0a00a01f46a61a4"},
-    {file = "cryptography-46.0.5-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:94a76daa32eb78d61339aff7952ea819b1734b46f73646a07decb40e5b3448e2"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5be7bf2fb40769e05739dd0046e7b26f9d4670badc7b032d6ce4db64dddc0678"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe346b143ff9685e40192a4960938545c699054ba11d4f9029f94751e3f71d87"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c69fd885df7d089548a42d5ec05be26050ebcd2283d89b3d30676eb32ff87dee"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:8293f3dea7fc929ef7240796ba231413afa7b68ce38fd21da2995549f5961981"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1abfdb89b41c3be0365328a410baa9df3ff8a9110fb75e7b52e66803ddabc9a9"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:d66e421495fdb797610a08f43b05269e0a5ea7f5e652a89bfd5a7d3c1dee3648"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:4e817a8920bfbcff8940ecfd60f23d01836408242b30f1a708d93198393a80b4"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:68f68d13f2e1cb95163fa3b4db4bf9a159a418f5f6e7242564fc75fcae667fd0"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a3d1fae9863299076f05cb8a778c467578262fae09f9dc0ee9b12eb4268ce663"},
-    {file = "cryptography-46.0.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4143987a42a2397f2fc3b4d7e3a7d313fbe684f67ff443999e803dd75a76826"},
-    {file = "cryptography-46.0.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7d731d4b107030987fd61a7f8ab512b25b53cef8f233a97379ede116f30eb67d"},
-    {file = "cryptography-46.0.5-cp314-cp314t-win32.whl", hash = "sha256:c3bcce8521d785d510b2aad26ae2c966092b7daa8f45dd8f44734a104dc0bc1a"},
-    {file = "cryptography-46.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:4d8ae8659ab18c65ced284993c2265910f6c9e650189d4e3f68445ef82a810e4"},
-    {file = "cryptography-46.0.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:4108d4c09fbbf2789d0c926eb4152ae1760d5a2d97612b92d508d96c861e4d31"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c"},
-    {file = "cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4"},
-    {file = "cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9"},
-    {file = "cryptography-46.0.5-cp38-abi3-win32.whl", hash = "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72"},
-    {file = "cryptography-46.0.5-cp38-abi3-win_amd64.whl", hash = "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595"},
-    {file = "cryptography-46.0.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:3b4995dc971c9fb83c25aa44cf45f02ba86f71ee600d81091c2f0cbae116b06c"},
-    {file = "cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:bc84e875994c3b445871ea7181d424588171efec3e185dced958dad9e001950a"},
-    {file = "cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:2ae6971afd6246710480e3f15824ed3029a60fc16991db250034efd0b9fb4356"},
-    {file = "cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d861ee9e76ace6cf36a6a89b959ec08e7bc2493ee39d07ffe5acb23ef46d27da"},
-    {file = "cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:2b7a67c9cd56372f3249b39699f2ad479f6991e62ea15800973b956f4b73e257"},
-    {file = "cryptography-46.0.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:8456928655f856c6e1533ff59d5be76578a7157224dbd9ce6872f25055ab9ab7"},
-    {file = "cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d"},
+    {file = "cryptography-48.0.1-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3e4a1a3232eef2e6c732827d5722db29a0cc8b27af2a4d865b094cf954be9ca1"},
+    {file = "cryptography-48.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:32143b24adb918f078134e1e230f1eb8cc04886b92c28b5f0041aaf3e5699225"},
+    {file = "cryptography-48.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0d27a5696721ef7a672b8c810f6aded391058e0b9486e63e6d93baf765da691"},
+    {file = "cryptography-48.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb86ce1af36fe65041b6db9a8bb064ee621a7e5fded0f80d475ec243477cd242"},
+    {file = "cryptography-48.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b024e784ad6c077ee0147b35ea9cbfc1e34e1fd4c1dcca214c2794d73a12df08"},
+    {file = "cryptography-48.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3752f2dbc8f07a30aad2932c986cea495b03bb554887828225da104f732852b6"},
+    {file = "cryptography-48.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:bd81490cd5801d755cf97bb68ac191f14b708470b1c7cf4580f669b9c9264cd8"},
+    {file = "cryptography-48.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:66fd0771e7b9c6dcd44cf1120690d2338d16d72795cf40cae2786a39eba65429"},
+    {file = "cryptography-48.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:3fd2ca57062b241c856670b073487d2e86c4637937ca5601e48f97bf8e11fc8f"},
+    {file = "cryptography-48.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:0ee6ea481db1ab889cba043ec1eda17bb9c1ea79db6722f779c3667f9f70322f"},
+    {file = "cryptography-48.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f2ceef93cb096aa3c4cc4b5c94ca6131f9196d28c64d6111533402a9b2054d41"},
+    {file = "cryptography-48.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9bd3f92d76217892b15df84ca256c2c113d386fdda7a7d8691aeeced976507c6"},
+    {file = "cryptography-48.0.1-cp311-abi3-win32.whl", hash = "sha256:b9a32b876490d66c8bcc9963ef220199569748434ab01a9d6aaeabf88e7f5158"},
+    {file = "cryptography-48.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:39489bfca54c7a1f6b297efcd8bc608ab92d16c4ca631b0cad4da46724588b24"},
+    {file = "cryptography-48.0.1-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:f817adc181390bd54f2f700107a7419040fb7c1bdf2fc26f36551a06a68c3345"},
+    {file = "cryptography-48.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d5d30989c6917b478b5817902e85fddaea2261efa8648383d965381ccb9e1ac4"},
+    {file = "cryptography-48.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:df637c05205ea7c1d7fbcbe54bbfea648a52951155f997af13d895d0ecc96991"},
+    {file = "cryptography-48.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:869c3b8a53bfe27147832df48b32adadf558249d50e76cb3769d40e986b13265"},
+    {file = "cryptography-48.0.1-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:e361afba8918070d376df76f408a4f67fec0ee9cff81a99e48fe9a233ef59e17"},
+    {file = "cryptography-48.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:d069066deead00ac7f090be101be875a06855908f7ec004c27b8fefb4acfb411"},
+    {file = "cryptography-48.0.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:09f73a725d582cef64b91281a322cd798d14a33b2b6f2b7ad9531dc336d84c02"},
+    {file = "cryptography-48.0.1-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:15254441469dd6bf027039453288e2072124f8b6603563f5d759e1c9b69273fa"},
+    {file = "cryptography-48.0.1-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:8ace4507d1e6533c125f4fac754f8bb8b6a74c08e92179dabd7e16571a3efbf3"},
+    {file = "cryptography-48.0.1-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b4e391975f038e66432328639620a4aff2d307513b004f1ca06d6225bced815c"},
+    {file = "cryptography-48.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:42fcd8e26fe555d9b3577a135f5091fefa0aa4e99129c23fb56787a1bd4ada72"},
+    {file = "cryptography-48.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c1400da5e32a43253392277eac7490a60e497d810a63dd5608d71bbd7af507c9"},
+    {file = "cryptography-48.0.1-cp314-cp314t-win32.whl", hash = "sha256:0df56b056bc17c1b7d6821dfa65216e62bd232d8ab05eb3db44e71d235651471"},
+    {file = "cryptography-48.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:9de21387aa95e2a895823d0745b430bed4f33503ba9ab5e0b5311f33e37d66d2"},
+    {file = "cryptography-48.0.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:4fdc69f8e4316bcf0c8c8ec1f26f285d12e8142d88d96c876a59a03be3f6ae67"},
+    {file = "cryptography-48.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48fe40804d4caa2288f24e70ca8c64c42dd826da0ad7e4f1b41b2128d679e6c8"},
+    {file = "cryptography-48.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:86be3b1b0b6bf09482fb50a979c508d2950ed95f5621ec77f4e385962006b83a"},
+    {file = "cryptography-48.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4ab0a343c807bbcd90c971cd1ecf072937cd01847a9e002bef88fb47ac6be577"},
+    {file = "cryptography-48.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9621de99d2da096006b629979efd8ae7eb2d8b822488d0c89ee4000c306c59b1"},
+    {file = "cryptography-48.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:88c852a0ae366e262e5a1744b685e6a433dc8788dd2a277e418bf4904203609d"},
+    {file = "cryptography-48.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:43c5835e2cb98c8733d86f57d6fc879b613f5c3478607281c3e36daffc6dd8a6"},
+    {file = "cryptography-48.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:fe0180af5bf9236518a087e35bf2d9a347d5f5f51e63c579d683ddff424e3d46"},
+    {file = "cryptography-48.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:b7a2d1a937a738a881737cec135a38bb61470589b17515b9f73f571d0ae10401"},
+    {file = "cryptography-48.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b74ca3b8e5ecdd833bf6a002ca41b4793bb27fb8f1c06ffaf2643c9e9140e31b"},
+    {file = "cryptography-48.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2c37f2461406063b417837f5f3daab668652acd82423efcd7f0a9f04be972de1"},
+    {file = "cryptography-48.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:86fe77abb1bd87afb251d4d02ada7ecf53a32cee9b67d976abb2e45a13297475"},
+    {file = "cryptography-48.0.1-cp39-abi3-win32.whl", hash = "sha256:6b2c0c3e6ccf3ade7750f836ef3ee36eea250cc467d45c256895573ac08cc6f1"},
+    {file = "cryptography-48.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:9a49ca6c81417f6a5edb50375a60cccdd70fa0a91a5211829dbea74eba94d2ac"},
+    {file = "cryptography-48.0.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:08a597acce1ff37f347400087776599e2348a3a8bc53b44120e463cd274efe4a"},
+    {file = "cryptography-48.0.1-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:735824ec41b7f74a7c45fb1591349333e4c696cb6c044e5f46356e560143e4cd"},
+    {file = "cryptography-48.0.1-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:92a46e1d638daa264ba2971c0b0489c9409787943efae4d60ffda3d091ef832c"},
+    {file = "cryptography-48.0.1-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:7e234ac052af99f2700826a5c29ea99d9c1b1f80341cde62d11c8154dc8e0bd9"},
+    {file = "cryptography-48.0.1-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:33842cf0888951cef5bc7ac724ab844a42044c1727b967b7f8997289a0464f92"},
+    {file = "cryptography-48.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:6184ca7b174f28d7c703f1290d4b297217c45355f77a98f67e9b7f14549ac54a"},
+    {file = "cryptography-48.0.1.tar.gz", hash = "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a"},
 ]
 
 [package.dependencies]
-cffi = {version = ">=2.0.0", markers = "python_full_version >= \"3.9.0\" and platform_python_implementation != \"PyPy\""}
+cffi = {version = ">=2.0.0", markers = "platform_python_implementation != \"PyPy\""}
 
 [package.extras]
-docs = ["sphinx (>=5.3.0)", "sphinx-inline-tabs", "sphinx-rtd-theme (>=3.0.0)"]
-docstest = ["pyenchant (>=3)", "readme-renderer (>=30.0)", "sphinxcontrib-spelling (>=7.3.1)"]
-nox = ["nox[uv] (>=2024.4.15)"]
-pep8test = ["check-sdist", "click (>=8.0.1)", "mypy (>=1.14)", "ruff (>=0.11.11)"]
-sdist = ["build (>=1.0.0)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["certifi (>=2024)", "cryptography-vectors (==46.0.5)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
-test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "cyclonedx-python-lib"
@@ -907,14 +900,14 @@ wmi = ["wmi (>=1.5.1) ; platform_system == \"Windows\""]
 
 [[package]]
 name = "ecdsa"
-version = "0.19.1"
+version = "0.19.2"
 description = "ECDSA cryptographic signature library (pure python)"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.6"
 groups = ["main"]
 files = [
-    {file = "ecdsa-0.19.1-py2.py3-none-any.whl", hash = "sha256:30638e27cf77b7e15c4c4cc1973720149e1033827cfd00661ca5c8cc0cdb24c3"},
-    {file = "ecdsa-0.19.1.tar.gz", hash = "sha256:478cba7b62555866fcb3bb3fe985e06decbdb68ef55713c4e5ab98c57d508e61"},
+    {file = "ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399"},
+    {file = "ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930"},
 ]
 
 [package.dependencies]
@@ -1233,18 +1226,18 @@ license = ["ukkonen"]
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"},
-    {file = "idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"},
+    {file = "idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"},
+    {file = "idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"},
 ]
 
 [package.extras]
-all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
+all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "iniconfig"
@@ -1343,14 +1336,14 @@ valkey = ["valkey (>=6)"]
 
 [[package]]
 name = "mako"
-version = "1.3.10"
+version = "1.3.12"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59"},
-    {file = "mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28"},
+    {file = "mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9"},
+    {file = "mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a"},
 ]
 
 [package.dependencies]

--- a/project-documents/user/project-guides/003-slices.office-hero.md
+++ b/project-documents/user/project-guides/003-slices.office-hero.md
@@ -165,6 +165,9 @@ Ordered by dependency and value. Each slice is independently demonstrable.
 21. [ ] **Tenant Admin web — Dispatch dashboard** — Route board view (all Vehicles + their
     Routes for the day), drag-and-drop resequencing, live Vehicle positions (polling),
     day-of exception handling UI. Dependencies: Slices 12–16, 20. Risk: High. Effort: 4/5
+    **Status:** Routes page shipped (per-day route board, manual stop resequencing via
+    move up/down + save, start/cancel route). Drag-and-drop, live vehicle positions,
+    and day-of exception flows remain.
 
 22. [x] **Technician web view** — Lighter React view: own Route for the day, Job details,
     basic Job entry. Separate from Technician Android app; useful for desktop/laptop use.

--- a/src/office_hero/api/app.py
+++ b/src/office_hero/api/app.py
@@ -37,6 +37,7 @@ from office_hero.api.routes.vehicle_location import create_vehicle_location_rout
 from office_hero.api.routes.vehicles import create_vehicle_router
 from office_hero.api.state import (
     get_route_repository,
+    get_route_stop_repository,
     set_auth_service,
     set_contract_service,
     set_customer_service,
@@ -273,29 +274,49 @@ def create_app(
         )
     set_schedule_suggestion_service(schedule_suggestion_service)
 
+    # Slice-14: shared route repositories — both the job dispatch service
+    # (suggested-slot booking) and the dispatch service (manual commit /
+    # resequence) must write the same Route/RouteStop store or the Routes
+    # view would only see half the dispatches.
+    _route_repo = None
+    _route_stop_repo = None
+    if dispatch_service is None:
+        _route_repo = InMemoryRouteRepository()
+        _route_stop_repo = InMemoryRouteStopRepository()
+        set_route_repository(_route_repo)
+        set_route_stop_repository(_route_stop_repo)
+    else:
+        # Injected dispatch service: reuse the route repos the caller
+        # registered (tests call set_route_repository before create_app) so
+        # a default JobDispatchService writes the same store.
+        try:
+            _route_repo = get_route_repository()
+            _route_stop_repo = get_route_stop_repository()
+        except RuntimeError:
+            pass
+
     # Slice-14: job dispatch service
     if job_dispatch_service is None:
         job_dispatch_service = JobDispatchService(
             job_repo=_default_job_repo or InMemoryJobRepository(),
             vehicle_repo=_default_v_repo or InMemoryVehicleRepository(),
+            route_repo=_route_repo,
+            stop_repo=_route_stop_repo,
+            crew_repo=vc_repo or InMemoryVehicleCrewRepository(),
         )
     set_job_dispatch_service(job_dispatch_service)
 
-    # Slice-14 (dispatch route management): route repositories and dispatch service
+    # Slice-14 (dispatch route management): dispatch service
     if dispatch_service is None:
-        route_repo = InMemoryRouteRepository()
-        route_stop_repo = InMemoryRouteStopRepository()
         dispatch_service = DispatchService(
-            route_repo=route_repo,
-            stop_repo=route_stop_repo,
+            route_repo=_route_repo,
+            stop_repo=_route_stop_repo,
             job_repo=_default_job_repo or InMemoryJobRepository(),
             vehicle_repo=_default_v_repo or InMemoryVehicleRepository(),
             vehicle_crew_repo=vc_repo or InMemoryVehicleCrewRepository(),
             schedule_service=schedule_suggestion_service,
             audit=audit,
         )
-        set_route_repository(route_repo)
-        set_route_stop_repository(route_stop_repo)
     set_dispatch_service(dispatch_service)
 
     application = FastAPI(

--- a/src/office_hero/api/routes/dispatch.py
+++ b/src/office_hero/api/routes/dispatch.py
@@ -14,6 +14,7 @@ from office_hero.api.schemas.dispatch import JobDispatchRequest, JobDispatchResp
 from office_hero.core.exceptions import (
     InvalidJobTransitionError,
     JobNotFoundError,
+    RouteCommitConflictError,
     VehicleAlreadyBookedError,
     VehicleNotFoundError,
 )
@@ -29,6 +30,13 @@ def _tenant_id(request: Request) -> UUID:
     raw = getattr(request.state, "tenant_id", None)
     if not raw:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+    return raw if isinstance(raw, UUID) else UUID(str(raw))
+
+
+def _user_id(request: Request) -> UUID | None:
+    raw = getattr(request.state, "user_id", None)
+    if not raw:
+        return None
     return raw if isinstance(raw, UUID) else UUID(str(raw))
 
 
@@ -53,11 +61,14 @@ def create_dispatch_router(*, service_provider) -> APIRouter:
         service = service_provider()
 
         try:
-            job = await service.dispatch(
+            job, route_id = await service.dispatch(
                 tenant_id,
                 job_id,
                 vehicle_id=body.vehicle_id,
                 scheduled_for=body.scheduled_for,
+                user_id=_user_id(request),
+                travel_seconds=body.travel_seconds,
+                distance_meters=body.distance_meters,
             )
         except JobNotFoundError as exc:
             raise HTTPException(
@@ -79,6 +90,11 @@ def create_dispatch_router(*, service_provider) -> APIRouter:
                 status_code=status.HTTP_409_CONFLICT,
                 detail=exc.message,
             ) from exc
+        except RouteCommitConflictError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=exc.message,
+            ) from exc
 
         return JobDispatchResponse(
             id=job.id,
@@ -88,6 +104,7 @@ def create_dispatch_router(*, service_provider) -> APIRouter:
             title=job.title,
             customer_id=job.customer_id,
             location_id=job.location_id,
+            route_id=route_id,
         )
 
     return router

--- a/src/office_hero/api/routes/routes.py
+++ b/src/office_hero/api/routes/routes.py
@@ -15,6 +15,7 @@ from office_hero.api.schemas.route import (
     RouteCancelRequest,
     RouteListResponse,
     RouteRead,
+    RouteResequenceRequest,
     StopSkipRequest,
 )
 from office_hero.core.exceptions import (
@@ -128,6 +129,39 @@ def create_routes_router(*, service_provider, repo_provider) -> APIRouter:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail=str(exc),
+            ) from exc
+
+        return route
+
+    @router.post(
+        "/{route_id}/resequence",
+        response_model=RouteRead,
+        dependencies=[Depends(require_permission("route:write"))],
+    )
+    @limiter.limit("60/minute")
+    async def resequence_route(
+        request: Request,
+        route_id: Annotated[UUID, Path()],
+        body: RouteResequenceRequest,
+    ) -> RouteRead:
+        """Reorder a committed route's stops — the manual sequence override."""
+        tenant_id = _tenant_id(request)
+        user_id = _user_id(request)
+        service = service_provider()
+
+        try:
+            route = await service.resequence_route(
+                tenant_id, user_id, route_id, job_ids=body.job_ids
+            )
+        except RouteNotFoundError as exc:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+        except InvalidRouteTransitionError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+            ) from exc
+        except ManualSequenceInvalidError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
             ) from exc
 
         return route

--- a/src/office_hero/api/schemas/dispatch.py
+++ b/src/office_hero/api/schemas/dispatch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from pydantic import AwareDatetime, BaseModel, ConfigDict
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
 
 
 class JobDispatchRequest(BaseModel):
@@ -12,6 +12,10 @@ class JobDispatchRequest(BaseModel):
 
     vehicle_id: UUID
     scheduled_for: AwareDatetime
+    # Plan metrics from the chosen suggestion — recorded on the RouteStop so
+    # the Routes view can show planned travel. Optional; default 0.
+    travel_seconds: int = Field(default=0, ge=0, le=86_400)
+    distance_meters: int = Field(default=0, ge=0, le=1_000_000)
 
 
 class JobDispatchResponse(BaseModel):
@@ -24,3 +28,5 @@ class JobDispatchResponse(BaseModel):
     title: str
     customer_id: UUID
     location_id: UUID
+    # Route the job was appended to (None only in unit-test wiring).
+    route_id: UUID | None = None

--- a/src/office_hero/api/schemas/route.py
+++ b/src/office_hero/api/schemas/route.py
@@ -111,6 +111,23 @@ class DispatchCommitRequest(BaseModel):
         return self
 
 
+class RouteResequenceRequest(BaseModel):
+    """Request to reorder a committed route's stops (manual override)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    job_ids: list[UUID]
+
+    @field_validator("job_ids")
+    @classmethod
+    def validate_job_ids(cls, v: list[UUID]) -> list[UUID]:
+        if not v:
+            raise ValueError("job_ids must not be empty")
+        if len(v) > 200:
+            raise ValueError("job_ids must contain at most 200 entries")
+        return v
+
+
 class RouteCancelRequest(BaseModel):
     """Request to cancel a route."""
 

--- a/src/office_hero/services/dispatch_service.py
+++ b/src/office_hero/services/dispatch_service.py
@@ -284,6 +284,73 @@ class DispatchService:
         await self._maybe_finalise_route(tenant_id, stop.route_id)
         return stop
 
+    async def resequence_route(
+        self, tenant_id: UUID, user_id: UUID, route_id: UUID, *, job_ids: list[UUID]
+    ) -> Route:
+        """Reorder the stops of a committed route — the manual override.
+
+        ``job_ids`` must be a permutation of the route's current stop jobs.
+        Only ``committed`` routes can be resequenced (day-of reordering of an
+        in-progress route is Slice 16 dynamic re-routing territory).
+        Per-stop planned metrics travel with their job; they are estimates
+        keyed to the old order, so totals are left unchanged.
+        """
+        route = await self._route_repo.get_by_id(route_id, tenant_id)
+        if route is None:
+            raise RouteNotFoundError(f"Route {route_id} not found")
+        if RouteStatus(route.status) != RouteStatus.COMMITTED:
+            raise InvalidRouteTransitionError(route.status, "resequenced")
+
+        stops = await self._stop_repo.get_for_route(tenant_id, route_id)
+        current_ids = {s.job_id for s in stops}
+        requested_ids = set(job_ids)
+        errors: list[str] = []
+        if len(job_ids) != len(requested_ids):
+            errors.append("job_ids contains duplicates")
+        if requested_ids != current_ids:
+            missing = current_ids - requested_ids
+            unknown = requested_ids - current_ids
+            if missing:
+                errors.append(f"missing jobs: {sorted(str(j) for j in missing)}")
+            if unknown:
+                errors.append(f"unknown jobs: {sorted(str(j) for j in unknown)}")
+        if errors:
+            raise ManualSequenceInvalidError(
+                "Resequence must be a permutation of the route's stops", errors=errors
+            )
+
+        by_job = {s.job_id: s for s in stops}
+        stop_rows = [
+            StopRow(
+                job_id=jid,
+                sequence_index=i,
+                planned_eta=by_job[jid].planned_eta,
+                planned_distance_from_prev_m=by_job[jid].planned_distance_from_prev_m,
+                planned_duration_from_prev_s=by_job[jid].planned_duration_from_prev_s,
+            )
+            for i, jid in enumerate(job_ids)
+        ]
+        new_stops = await self._stop_repo.replace_all(tenant_id, route_id, stop_rows)
+        route.stops = new_stops
+
+        if self._audit is not None:
+            await self._audit.log_event(
+                event_type="route.resequenced",
+                details={
+                    "route_id": str(route_id),
+                    "sequence": [str(j) for j in job_ids],
+                },
+                tenant_id=tenant_id,
+                user_id=user_id,
+            )
+        log.info(
+            "route.resequenced",
+            route_id=str(route_id),
+            stop_count=len(job_ids),
+            tenant_id=str(tenant_id),
+        )
+        return route
+
     # ------------------------------------------------------------------
     # Read helpers
     # ------------------------------------------------------------------

--- a/src/office_hero/services/job_dispatch_service.py
+++ b/src/office_hero/services/job_dispatch_service.py
@@ -2,6 +2,13 @@
 
 The single public method ``dispatch`` handles the full atomic transition:
   pending → scheduled, with vehicle assignment and conflict detection.
+
+When route repositories are wired (the production configuration), dispatching
+also materialises the day's Route: the job is appended as a RouteStop on the
+vehicle's route for ``scheduled_for.date()``, creating the route (with its
+crew) if it doesn't exist yet.  This is what makes the admin "pick a suggested
+slot" flow produce the same persistent Route/RouteStop records as the manual
+``POST /routes`` commit path (Slice 14).
 """
 
 from __future__ import annotations
@@ -12,28 +19,43 @@ from uuid import UUID
 from office_hero.core.exceptions import (
     InvalidJobTransitionError,
     JobNotFoundError,
+    RouteCommitConflictError,
     VehicleAlreadyBookedError,
     VehicleNotFoundError,
 )
 from office_hero.core.job_status import JobStatus, can_transition
 from office_hero.core.logging import get_logger
+from office_hero.core.route_status import RouteStatus
 from office_hero.models.job import Job
 from office_hero.repositories.job_repository import JobRepositoryProtocol
+from office_hero.repositories.route_repository import RouteCreateRow
+from office_hero.repositories.route_stop_repository import StopRow
 from office_hero.repositories.vehicle_repository import VehicleRepositoryProtocol
 
 log = get_logger(__name__)
 
 
 class JobDispatchService:
-    """Orchestrates the scheduling / dispatch of a job to a vehicle."""
+    """Orchestrates the scheduling / dispatch of a job to a vehicle.
+
+    ``route_repo`` / ``stop_repo`` / ``crew_repo`` are optional for unit tests
+    that only exercise the job-state half; production wiring always passes
+    them so dispatching keeps Routes in sync.
+    """
 
     def __init__(
         self,
         job_repo: JobRepositoryProtocol,
         vehicle_repo: VehicleRepositoryProtocol,
+        route_repo=None,
+        stop_repo=None,
+        crew_repo=None,
     ) -> None:
         self._job_repo = job_repo
         self._vehicle_repo = vehicle_repo
+        self._route_repo = route_repo
+        self._stop_repo = stop_repo
+        self._crew_repo = crew_repo
 
     async def dispatch(
         self,
@@ -42,14 +64,22 @@ class JobDispatchService:
         *,
         vehicle_id: UUID,
         scheduled_for: datetime,
-    ) -> Job:
-        """Assign *vehicle_id* to *job_id* and schedule it for *scheduled_for*.
+        user_id: UUID | None = None,
+        travel_seconds: int = 0,
+        distance_meters: int = 0,
+    ) -> tuple[Job, UUID | None]:
+        """Assign *vehicle_id* to *job_id*, schedule it, and sync the day's Route.
+
+        Returns ``(job, route_id)`` — ``route_id`` is None when route
+        repositories are not wired (unit-test configuration).
 
         Raises:
             JobNotFoundError: job doesn't exist in this tenant.
             VehicleNotFoundError: vehicle doesn't exist in this tenant.
             InvalidJobTransitionError: job is not in a dispatchable state.
             VehicleAlreadyBookedError: vehicle has an overlapping scheduled job.
+            RouteCommitConflictError: vehicle has no crew for the date, or the
+                route is already in_progress/complete/cancelled.
         """
         job = await self._job_repo.get_by_id(job_id, tenant_id)
         if job is None:
@@ -82,6 +112,41 @@ class JobDispatchService:
                 scheduled_for=scheduled_for,
             )
 
+        # Validate the route side BEFORE mutating the job so a crew/route
+        # conflict leaves the job untouched.
+        route = None
+        crew = None
+        existing_stops = []
+        routes_wired = self._route_repo is not None and self._stop_repo is not None
+        if routes_wired:
+            work_date = scheduled_for.date()
+            route = await self._route_repo.get_for_vehicle_date(tenant_id, vehicle_id, work_date)
+            if route is not None:
+                route_status = RouteStatus(route.status)
+                if route_status in (
+                    RouteStatus.IN_PROGRESS,
+                    RouteStatus.COMPLETE,
+                    RouteStatus.CANCELLED,
+                ):
+                    raise RouteCommitConflictError(
+                        f"Route for this vehicle on {work_date} is already {route_status}",
+                        reason=f"route_{route_status}",
+                    )
+                existing_stops = await self._stop_repo.get_for_route(tenant_id, route.id)
+            else:
+                if self._crew_repo is None:
+                    raise RouteCommitConflictError(
+                        "Crew repository not configured", reason="no_crew_repo"
+                    )
+                crew = await self._crew_repo.get_for_vehicle_date(
+                    tenant_id, vehicle_id, work_date
+                )
+                if crew is None:
+                    raise RouteCommitConflictError(
+                        f"Vehicle {vehicle_id} has no crew assigned for {work_date}",
+                        reason="no_crew",
+                    )
+
         updated = await self._job_repo.update_fields(
             job_id,
             tenant_id,
@@ -89,11 +154,66 @@ class JobDispatchService:
             assigned_vehicle_id=vehicle_id,
             scheduled_for=scheduled_for,
         )
+
+        route_id: UUID | None = None
+        if routes_wired:
+            if route is None:
+                route = await self._route_repo.create(
+                    tenant_id,
+                    row=RouteCreateRow(
+                        vehicle_id=vehicle_id,
+                        vehicle_crew_id=crew.id,
+                        work_date=scheduled_for.date(),
+                        committed_by_user_id=user_id,
+                        option_kind_applied="suggested",
+                        notes=None,
+                        total_distance_m=distance_meters,
+                        total_duration_s=travel_seconds,
+                    ),
+                )
+                inserted = await self._stop_repo.bulk_insert(
+                    tenant_id,
+                    route.id,
+                    [
+                        StopRow(
+                            job_id=job_id,
+                            sequence_index=0,
+                            planned_eta=scheduled_for,
+                            planned_distance_from_prev_m=distance_meters,
+                            planned_duration_from_prev_s=travel_seconds,
+                        )
+                    ],
+                )
+                route.stops = inserted
+            elif all(s.job_id != job_id for s in existing_stops):
+                inserted = await self._stop_repo.bulk_insert(
+                    tenant_id,
+                    route.id,
+                    [
+                        StopRow(
+                            job_id=job_id,
+                            sequence_index=len(existing_stops),
+                            planned_eta=scheduled_for,
+                            planned_distance_from_prev_m=distance_meters,
+                            planned_duration_from_prev_s=travel_seconds,
+                        )
+                    ],
+                )
+                route.stops = [*existing_stops, *inserted]
+                await self._route_repo.update_totals(
+                    route.id,
+                    tenant_id,
+                    total_distance_m=route.total_distance_m + distance_meters,
+                    total_duration_s=route.total_duration_s + travel_seconds,
+                )
+            route_id = route.id
+
         log.info(
             "job.dispatched",
             job_id=str(job_id),
             vehicle_id=str(vehicle_id),
             scheduled_for=scheduled_for.isoformat(),
+            route_id=str(route_id) if route_id else None,
             tenant_id=str(tenant_id),
         )
-        return updated
+        return updated, route_id

--- a/src/office_hero/services/job_dispatch_service.py
+++ b/src/office_hero/services/job_dispatch_service.py
@@ -138,9 +138,7 @@ class JobDispatchService:
                     raise RouteCommitConflictError(
                         "Crew repository not configured", reason="no_crew_repo"
                     )
-                crew = await self._crew_repo.get_for_vehicle_date(
-                    tenant_id, vehicle_id, work_date
-                )
+                crew = await self._crew_repo.get_for_vehicle_date(tenant_id, vehicle_id, work_date)
                 if crew is None:
                     raise RouteCommitConflictError(
                         f"Vehicle {vehicle_id} has no crew assigned for {work_date}",

--- a/tests/api/test_dispatch_routes_flow.py
+++ b/tests/api/test_dispatch_routes_flow.py
@@ -1,0 +1,395 @@
+"""HTTP-layer tests for the dispatch → Route flow (suggested + manual override).
+
+Covers the gap the original Slice-14 tests left open:
+* POST /jobs/{id}/dispatch (the admin "pick a suggested slot" path) must
+  create/append persistent Route + RouteStop records, not just flip job state.
+* POST /routes manual mode (custom vehicle + sequence) — the "fourth option".
+* POST /routes/{id}/resequence — reordering a committed route.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, date, datetime, time, timedelta
+from uuid import uuid4
+
+import pytest
+from fastapi import Request
+from fastapi.testclient import TestClient
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from office_hero.api.app import create_app
+from office_hero.api.state import (
+    set_dispatch_service,
+    set_route_repository,
+    set_route_stop_repository,
+)
+from office_hero.core.crew_role import CrewRole
+from office_hero.repositories.job_repository import InMemoryJobRepository
+from office_hero.repositories.mocks import InMemoryAuditService
+from office_hero.repositories.route_repository import InMemoryRouteRepository
+from office_hero.repositories.route_stop_repository import InMemoryRouteStopRepository
+from office_hero.repositories.vehicle_crew_repository import (
+    CrewMemberInput,
+    InMemoryVehicleCrewRepository,
+)
+from office_hero.repositories.vehicle_repository import InMemoryVehicleRepository
+from office_hero.services.dispatch_service import DispatchService
+from office_hero.services.job_dispatch_service import JobDispatchService
+
+
+class _FlowAuthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        request.state.tenant_id = request.headers.get("X-Test-Tenant-Id")
+        request.state.user_id = request.headers.get("X-Test-User-Id")
+        request.state.role = request.headers.get("X-Test-Role", "dispatcher")
+        perms = request.headers.get("X-Test-Permissions", "")
+        request.state.permissions = [p.strip() for p in perms.split(",") if p.strip()]
+        return await call_next(request)
+
+
+def _auth_headers(tenant_id, user_id):
+    return {
+        "X-Test-Tenant-Id": str(tenant_id),
+        "X-Test-User-Id": str(user_id),
+        "X-Test-Role": "dispatcher",
+        "X-Test-Permissions": "route:write,route:read,job:write,vehicle:read",
+    }
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _isolate_rate_limit_key() -> list[tuple]:
+    """Point every registered rate limit at a fresh key (see golden path test)."""
+    from office_hero.api.limiter import limiter
+
+    test_key = str(uuid4())
+    saved: list[tuple] = []
+    for limits in limiter._route_limits.values():
+        for lim in limits:
+            saved.append((lim, lim.key_func))
+            lim.key_func = lambda *_a, **_k: test_key
+    return saved
+
+
+@pytest.fixture()
+def setup():
+    """Full app with shared job/vehicle/route repos and both dispatch services."""
+    tenant_id = uuid4()
+    user_id = uuid4()
+
+    job_repo = InMemoryJobRepository()
+    vehicle_repo = InMemoryVehicleRepository()
+    vc_repo = InMemoryVehicleCrewRepository()
+    route_repo = InMemoryRouteRepository()
+    stop_repo = InMemoryRouteStopRepository()
+    audit = InMemoryAuditService()
+
+    job_dispatch_svc = JobDispatchService(
+        job_repo=job_repo,
+        vehicle_repo=vehicle_repo,
+        route_repo=route_repo,
+        stop_repo=stop_repo,
+        crew_repo=vc_repo,
+    )
+    dispatch_svc = DispatchService(
+        route_repo=route_repo,
+        stop_repo=stop_repo,
+        job_repo=job_repo,
+        vehicle_repo=vehicle_repo,
+        vehicle_crew_repo=vc_repo,
+        schedule_service=None,  # manual mode + resequence don't consult it
+        audit=audit,
+    )
+
+    set_route_repository(route_repo)
+    set_route_stop_repository(stop_repo)
+    set_dispatch_service(dispatch_svc)
+
+    from office_hero.api.limiter import limiter
+
+    saved_route_limits = dict(limiter._route_limits)
+    limiter._route_limits.clear()
+    app = create_app(
+        job_dispatch_service=job_dispatch_svc,
+        dispatch_service=dispatch_svc,
+    )
+    app.add_middleware(_FlowAuthMiddleware)
+
+    saved_key_funcs = _isolate_rate_limit_key()
+
+    with TestClient(app) as client:
+        yield {
+            "client": client,
+            "tenant_id": tenant_id,
+            "user_id": user_id,
+            "job_repo": job_repo,
+            "vehicle_repo": vehicle_repo,
+            "vc_repo": vc_repo,
+            "route_repo": route_repo,
+            "stop_repo": stop_repo,
+        }
+
+    for lim, orig in saved_key_funcs:
+        lim.key_func = orig
+    limiter._route_limits.clear()
+    limiter._route_limits.update(saved_route_limits)
+
+
+async def _seed_vehicle_with_crew(setup_data, *, work_date=None):
+    tenant_id = setup_data["tenant_id"]
+    user_id = setup_data["user_id"]
+    vehicle = await setup_data["vehicle_repo"].create(
+        tenant_id,
+        license_plate="ABC-123",
+        nickname="Van #1",
+        make="Ford",
+        model="Transit",
+        year=2022,
+    )
+    await setup_data["vc_repo"].create(
+        tenant_id,
+        vehicle_id=vehicle.id,
+        work_date=work_date or date.today(),
+        shift_start=time(8, 0),
+        shift_end=time(17, 0),
+        notes=None,
+        created_by_user_id=user_id,
+        members=[CrewMemberInput(user_id=user_id, role_on_crew=CrewRole.LEAD)],
+    )
+    return vehicle
+
+
+async def _seed_job(setup_data, *, title="Fix leaking pipe"):
+    return await setup_data["job_repo"].create(
+        setup_data["tenant_id"],
+        customer_id=uuid4(),
+        location_id=uuid4(),
+        industry="plumbing",
+        title=title,
+        created_by_user_id=setup_data["user_id"],
+    )
+
+
+def _slot(hour: int) -> str:
+    return (
+        datetime.combine(date.today(), time(hour, 0), tzinfo=UTC) + timedelta(days=0)
+    ).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# POST /jobs/{id}/dispatch — suggested-slot path now creates Routes
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_creates_route_and_stop(setup):
+    client = setup["client"]
+    headers = _auth_headers(setup["tenant_id"], setup["user_id"])
+    vehicle = _run(_seed_vehicle_with_crew(setup))
+    job = _run(_seed_job(setup))
+
+    resp = client.post(
+        f"/jobs/{job.id}/dispatch",
+        json={
+            "vehicle_id": str(vehicle.id),
+            "scheduled_for": _slot(9),
+            "travel_seconds": 900,
+            "distance_meters": 12000,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "scheduled"
+    assert body["route_id"] is not None
+
+    route = client.get(f"/routes/{body['route_id']}", headers=headers).json()
+    assert route["status"] == "committed"
+    assert route["option_kind_applied"] == "suggested"
+    assert route["total_duration_s"] == 900
+    assert len(route["stops"]) == 1
+    assert route["stops"][0]["job_id"] == str(job.id)
+    assert route["stops"][0]["sequence_index"] == 0
+
+
+def test_second_dispatch_same_vehicle_appends_stop(setup):
+    client = setup["client"]
+    headers = _auth_headers(setup["tenant_id"], setup["user_id"])
+    vehicle = _run(_seed_vehicle_with_crew(setup))
+    job1 = _run(_seed_job(setup, title="Morning job"))
+    job2 = _run(_seed_job(setup, title="Afternoon job"))
+
+    first = client.post(
+        f"/jobs/{job1.id}/dispatch",
+        json={"vehicle_id": str(vehicle.id), "scheduled_for": _slot(9)},
+        headers=headers,
+    )
+    assert first.status_code == 200, first.text
+    second = client.post(
+        f"/jobs/{job2.id}/dispatch",
+        json={"vehicle_id": str(vehicle.id), "scheduled_for": _slot(13)},
+        headers=headers,
+    )
+    assert second.status_code == 200, second.text
+    assert second.json()["route_id"] == first.json()["route_id"]
+
+    route = client.get(f"/routes/{first.json()['route_id']}", headers=headers).json()
+    assert [s["job_id"] for s in route["stops"]] == [str(job1.id), str(job2.id)]
+    assert [s["sequence_index"] for s in route["stops"]] == [0, 1]
+
+
+def test_dispatch_without_crew_409_and_job_untouched(setup):
+    client = setup["client"]
+    headers = _auth_headers(setup["tenant_id"], setup["user_id"])
+    # Vehicle WITHOUT a crew for today.
+    vehicle = _run(
+        setup["vehicle_repo"].create(
+            setup["tenant_id"],
+            license_plate="NOCREW-1",
+            nickname="Crewless",
+            make="Ford",
+            model="Transit",
+            year=2022,
+        )
+    )
+    job = _run(_seed_job(setup))
+
+    resp = client.post(
+        f"/jobs/{job.id}/dispatch",
+        json={"vehicle_id": str(vehicle.id), "scheduled_for": _slot(9)},
+        headers=headers,
+    )
+    assert resp.status_code == 409
+    assert "crew" in resp.json()["detail"].lower()
+
+    refreshed = _run(setup["job_repo"].get_by_id(job.id, setup["tenant_id"]))
+    assert refreshed.status == "pending"
+    assert refreshed.assigned_vehicle_id is None
+
+
+# ---------------------------------------------------------------------------
+# POST /routes — manual mode (the "fourth custom option")
+# ---------------------------------------------------------------------------
+
+
+def test_manual_commit_creates_route_with_custom_sequence(setup):
+    client = setup["client"]
+    headers = _auth_headers(setup["tenant_id"], setup["user_id"])
+    vehicle = _run(_seed_vehicle_with_crew(setup))
+    job1 = _run(_seed_job(setup, title="Stop A"))
+    job2 = _run(_seed_job(setup, title="Stop B"))
+
+    resp = client.post(
+        f"/routes?job_id={job1.id}",
+        json={
+            "date": date.today().isoformat(),
+            "manual_vehicle_id": str(vehicle.id),
+            "manual_sequence": [str(job2.id), str(job1.id)],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    route = resp.json()
+    assert route["option_kind_applied"] == "manual"
+    assert [s["job_id"] for s in route["stops"]] == [str(job2.id), str(job1.id)]
+
+
+def test_manual_commit_with_unknown_job_422(setup):
+    client = setup["client"]
+    headers = _auth_headers(setup["tenant_id"], setup["user_id"])
+    vehicle = _run(_seed_vehicle_with_crew(setup))
+    job = _run(_seed_job(setup))
+
+    resp = client.post(
+        f"/routes?job_id={job.id}",
+        json={
+            "date": date.today().isoformat(),
+            "manual_vehicle_id": str(vehicle.id),
+            "manual_sequence": [str(job.id), str(uuid4())],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# POST /routes/{id}/resequence — reorder a committed route
+# ---------------------------------------------------------------------------
+
+
+def _commit_two_stop_route(setup) -> tuple[str, str, str]:
+    """Dispatch two jobs onto one vehicle; return (route_id, job1_id, job2_id)."""
+    client = setup["client"]
+    headers = _auth_headers(setup["tenant_id"], setup["user_id"])
+    vehicle = _run(_seed_vehicle_with_crew(setup))
+    job1 = _run(_seed_job(setup, title="First"))
+    job2 = _run(_seed_job(setup, title="Second"))
+    first = client.post(
+        f"/jobs/{job1.id}/dispatch",
+        json={"vehicle_id": str(vehicle.id), "scheduled_for": _slot(9)},
+        headers=headers,
+    )
+    client.post(
+        f"/jobs/{job2.id}/dispatch",
+        json={"vehicle_id": str(vehicle.id), "scheduled_for": _slot(13)},
+        headers=headers,
+    )
+    return first.json()["route_id"], str(job1.id), str(job2.id)
+
+
+def test_resequence_reorders_stops(setup):
+    client = setup["client"]
+    headers = _auth_headers(setup["tenant_id"], setup["user_id"])
+    route_id, job1_id, job2_id = _commit_two_stop_route(setup)
+
+    resp = client.post(
+        f"/routes/{route_id}/resequence",
+        json={"job_ids": [job2_id, job1_id]},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    route = resp.json()
+    assert [s["job_id"] for s in route["stops"]] == [job2_id, job1_id]
+    assert [s["sequence_index"] for s in route["stops"]] == [0, 1]
+
+
+def test_resequence_rejects_non_permutation_422(setup):
+    client = setup["client"]
+    headers = _auth_headers(setup["tenant_id"], setup["user_id"])
+    route_id, job1_id, _job2_id = _commit_two_stop_route(setup)
+
+    resp = client.post(
+        f"/routes/{route_id}/resequence",
+        json={"job_ids": [job1_id, str(uuid4())]},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+def test_resequence_rejects_in_progress_route_422(setup):
+    client = setup["client"]
+    headers = _auth_headers(setup["tenant_id"], setup["user_id"])
+    route_id, job1_id, job2_id = _commit_two_stop_route(setup)
+
+    started = client.post(f"/routes/{route_id}/start", headers=headers)
+    assert started.status_code == 200
+
+    resp = client.post(
+        f"/routes/{route_id}/resequence",
+        json={"job_ids": [job2_id, job1_id]},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+def test_resequence_route_not_found_404(setup):
+    client = setup["client"]
+    headers = _auth_headers(setup["tenant_id"], setup["user_id"])
+    resp = client.post(
+        f"/routes/{uuid4()}/resequence",
+        json={"job_ids": [str(uuid4())]},
+        headers=headers,
+    )
+    assert resp.status_code == 404

--- a/tools/server_manager.py
+++ b/tools/server_manager.py
@@ -318,6 +318,11 @@ def _spawn_process(name: str, command: list[str], env: dict[str, str]) -> subpro
     _runtime_mkdir()
     log_file = RUNTIME_DIR / f"{name}.log"
     log_handle = log_file.open("w", encoding="utf-8")
+    # On Windows, npm-family launchers are .cmd shims (pnpm.cmd) which
+    # CreateProcess cannot exec by bare name — resolve via PATH lookup.
+    resolved = shutil.which(command[0])
+    if resolved:
+        command = [resolved, *command[1:]]
     try:
         proc = subprocess.Popen(
             command,


### PR DESCRIPTION
## Summary

Completes the core product promise — **suggested routes for trucks that dispatchers can then override**. Stacked on #109.

### Backend
- `POST /jobs/{id}/dispatch` (the admin 'pick a suggested slot' path) now materialises the day's **Route + RouteStop** for the vehicle, creating the route (with crew) when absent and appending stops otherwise; crew/route-state conflicts return 409 *before* the job is mutated
- Both dispatch services share one route store in `create_app` so the Routes view sees every dispatch
- New `POST /routes/{id}/resequence`: permutation-validated stop reorder of a committed route (`DispatchService.resequence_route`)
- 9 new flow tests covering route creation/append, no-crew 409, manual commit, and resequencing

### Frontend (admin-web)
- ScheduleModal gains **'Assign manually instead'** — any vehicle, any time (the concept doc's 'fourth custom option')
- New **Routes page**: per-day route board, ordered stops with status, move-up/down resequencing with save, start/cancel route with reason
- 6 new Jest tests (37 total)

### Infra (unblocking the local pre-push gate)
- `tools/server_manager.py`: resolve `pnpm.cmd` via `shutil.which` (Windows)
- Dependency CVE sweep: starlette 1.3 / fastapi 0.136 / urllib3 / requests / pytest / pygments / python-multipart / cryptography / idna / mako / ecdsa / pyasn1 — clears every pip-audit finding; the one wontfix CVE (ecdsa Minerva) is ignored with documentation

Full suite: **452 passed backend**, 37 admin-web, lint/bandit/pip-audit green via the now-active `.githooks` pre-push gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)