### PR TITLE
feat(slice-24): back-office adapter seam — CRM integration ready

### DIFF
--- a/alembic/versions/0012_backoffice_seam.py
+++ b/alembic/versions/0012_backoffice_seam.py
@@ -1,0 +1,77 @@
+"""Back-office seam hardening: outbox/saga indexes + RLS, tenant adapter column (Slice 24)
+
+Revision ID: 0012_backoffice_seam
+Revises: 0011_contracts
+Create Date: 2026-06-12 00:00:00.000000
+
+* ``outbox_events``: + ``dead_letter_reason`` (protocol + admin UI already use it),
+  index ``(tenant_id, status, created_at)`` for the pending-poll, RLS policy.
+* ``saga_log``: + ``last_error``, index ``(tenant_id, saga_type)``, RLS policy.
+* ``tenants``: + ``back_office_adapter`` (default ``native``) with CHECK on the
+  known adapter registry names.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0012_backoffice_seam"
+down_revision = "0011_contracts"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("outbox_events", sa.Column("dead_letter_reason", sa.Text(), nullable=True))
+    op.create_index(
+        "idx_outbox_tenant_status_created",
+        "outbox_events",
+        ["tenant_id", "status", "created_at"],
+    )
+    op.execute(
+        """
+        ALTER TABLE outbox_events ENABLE ROW LEVEL SECURITY;
+        CREATE POLICY outbox_tenant_isolation ON outbox_events
+            USING (tenant_id = current_setting('app.tenant_id'));
+        """
+    )
+
+    op.add_column("saga_log", sa.Column("last_error", sa.Text(), nullable=True))
+    op.create_index("idx_saga_log_tenant_type", "saga_log", ["tenant_id", "saga_type"])
+    op.execute(
+        """
+        ALTER TABLE saga_log ENABLE ROW LEVEL SECURITY;
+        CREATE POLICY saga_log_tenant_isolation ON saga_log
+            USING (tenant_id = current_setting('app.tenant_id'));
+        """
+    )
+
+    op.add_column(
+        "tenants",
+        sa.Column(
+            "back_office_adapter",
+            sa.String(50),
+            nullable=False,
+            server_default="native",
+        ),
+    )
+    op.create_check_constraint(
+        "ck_tenant_back_office_adapter",
+        "tenants",
+        "back_office_adapter IN ('native','servicetitan','pestpac','jobber')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_tenant_back_office_adapter", "tenants", type_="check")
+    op.drop_column("tenants", "back_office_adapter")
+
+    op.execute("DROP POLICY IF EXISTS saga_log_tenant_isolation ON saga_log;")
+    op.execute("ALTER TABLE saga_log DISABLE ROW LEVEL SECURITY;")
+    op.drop_index("idx_saga_log_tenant_type", table_name="saga_log")
+    op.drop_column("saga_log", "last_error")
+
+    op.execute("DROP POLICY IF EXISTS outbox_tenant_isolation ON outbox_events;")
+    op.execute("ALTER TABLE outbox_events DISABLE ROW LEVEL SECURITY;")
+    op.drop_index("idx_outbox_tenant_status_created", table_name="outbox_events")
+    op.drop_column("outbox_events", "dead_letter_reason")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-hero-mobile",
-  "version": "0.1.18",
+  "version": "0.1.20",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/project-documents/user/project-guides/003-slices.office-hero.md
+++ b/project-documents/user/project-guides/003-slices.office-hero.md
@@ -201,10 +201,14 @@ Each integration is a separate slice. All implement the `BackOfficeAdapter` prot
 > - Integration test simulating failure at each Saga step
 > - Dead-letter handling via `GET /admin/dead-letters` (Operator-only)
 
-24. [ ] **BackOfficeAdapter protocol** — Define the full protocol ABC; refactor all
+24. [x] **BackOfficeAdapter protocol** — Define the full protocol ABC; refactor all
     existing code to call the NativeAdapter through it (NativeAdapter is already
     the default; this slice makes the seam explicit and tested). Includes `health_check()`
     method and Saga base class.
+    **Status:** Complete — NativeAdapter implemented (tenant-scoped, local repos),
+    adapter registry, SQL-backed outbox/saga repositories, tenants.back_office_adapter
+    column, contract-create → outbox → adapter sync loop with dead-lettering
+    (design: 024-slice.backoffice-adapter.md).
     Dependencies: Slices 10–12. Risk: Medium. Effort: 2/5
 
 25. [ ] **ServiceTitan integration** — Adapter implementing BackOfficeAdapter against

--- a/project-documents/user/slices/024-slice.backoffice-adapter.md
+++ b/project-documents/user/slices/024-slice.backoffice-adapter.md
@@ -1,0 +1,105 @@
+---
+docType: slice-design
+parent: ../project-guides/003-slices.office-hero.md
+project: office-hero
+dateCreated: 20260612
+dateUpdated: 20260612
+status: in_progress
+slice: backoffice-adapter
+---
+
+# Slice Design 024: BackOfficeAdapter protocol seam
+
+Implements **Slice 24** of the master plan: make the back-office integration seam
+explicit, tested, and persistent, with `NativeAdapter` (Office Hero as system of
+record) as the working default. This is what "works with the customer's existing CRM
+or whatever" hangs off: ServiceTitan/PestPac/Jobber adapters (slices 25–27) drop into
+this seam without touching domain services.
+
+Existing scaffolding (saga base, protocols, in-memory mocks, dead-letter admin routes)
+stays; this slice fills the gaps ADR 056 mandates.
+
+## What lands
+
+### 1. Persistent outbox/saga (DB-backed repositories)
+
+* `models/outbox_event.py` + `models/saga_log.py` — ORM models mapping the existing
+  `outbox_events` / `saga_log` tables from migration 0001 (string-36 ids preserved).
+* Migration `0012_backoffice_seam.py`:
+  * `outbox_events`: + `dead_letter_reason TEXT` (the protocol and admin UI already
+    expect it), index `(tenant_id, status, created_at)`, RLS policy (ADR 053 pattern).
+  * `saga_log`: + `last_error TEXT`, index `(tenant_id, saga_type)`, RLS policy.
+  * `tenants`: + `back_office_adapter VARCHAR(50) NOT NULL DEFAULT 'native'` with a
+    CHECK constraint on known adapter names.
+* `repositories/outbox_repository.py` — `SqlOutboxRepository` implementing the full
+  `OutboxRepository` protocol (incl. `list_events`, so the admin dead-letter routes
+  work unchanged against Postgres).
+* `repositories/saga_repository.py` — `SqlSagaRepository` implementing `SagaRepository`.
+
+### 2. NativeAdapter for real + adapter registry
+
+* `NativeAdapter(tenant_id, customer_repo, job_repo)` — implements every protocol
+  method against local repositories; no more `NotImplementedError`. Create/update
+  calls are upsert-by-`external_id` no-ops in the native case (Office Hero IS the
+  system of record), reads delegate to the repos.
+* `adapters/back_office/registry.py` — `get_adapter_factory(name)`; `'native'` is
+  registered; unknown names raise `UnknownBackOfficeAdapterError` (422 at the API).
+  Slices 25–27 register `'servicetitan'`, `'pestpac'`, `'jobber'` here.
+
+### 3. The sync seam, end-to-end on Contracts
+
+* `ContractService` gains an optional `outbox` dependency: `create()` enqueues a
+  `backoffice.contract.created` outbox event (idempotency key = contract id) in the
+  same unit of work — the Transactional Outbox of ADR 056.
+* `services/back_office_sync_service.py` — `BackOfficeSyncService.process_pending
+  (tenant_id, limit)`: claims pending events, resolves the tenant's adapter via the
+  registry, dispatches by event type, marks done; failures increment `attempt_count`
+  and dead-letter after `MAX_ATTEMPTS=5` with the error as `dead_letter_reason`.
+  Retry of a dead-letter (existing admin endpoint) resets it to pending.
+* `POST /admin/outbox/process` (Operator-only) — processes pending events for a
+  tenant. v1 trigger is manual/cron (same posture as contract job generation); a
+  background poller is future work, the seam doesn't change.
+
+## Out of scope (tracked)
+
+* ServiceTitan/PestPac/Jobber concrete adapters (slices 25–27) — need credentials
+  and sandbox accounts.
+* Background outbox poller (cron calls the admin endpoint for now).
+* Tenant admin UI for choosing an adapter (operator sets the column; UI rides the
+  tenant management page when slices 25+ make multiple adapters real).
+* Production DB wiring of these repos into `create_app` defaults follows the
+  existing per-service injection pattern.
+
+## Tests
+
+* `tests/unit/test_native_adapter.py` — every protocol method against in-memory
+  repos; tenant scoping enforced; registry resolution incl. unknown name.
+* `tests/integration/test_sql_outbox_repository.py` — full lifecycle (create →
+  pending → processing → done / dead-letter → retry → list_events filters) against
+  aiosqlite.
+* `tests/integration/test_sql_saga_repository.py` — create/get/update status +
+  step/context merge/last_error against aiosqlite.
+* `tests/unit/test_back_office_sync_service.py` — happy path marks done; failing
+  adapter increments attempts; exhaustion dead-letters with reason; unknown event
+  type dead-letters; idempotent reprocessing.
+* `tests/unit/test_contract_service.py` — contract create enqueues outbox event
+  with idem key (new test in existing file).
+* `tests/api/test_admin_outbox_api.py` — operator-only process endpoint.
+
+## Dependencies
+
+Slices 2 (DB), 3 (RBAC), existing saga/outbox scaffolding, Slice 11 (contracts —
+first producer through the seam). ADRs 053, 056, 058, 063.
+
+## Effort: 3/5
+
+## Risk callouts
+
+* **String-36 ids on legacy tables** — kept as-is to avoid a risky type migration;
+  repos convert at the boundary. Revisit when slices 25–27 land.
+* **RLS + operator flows** — outbox/saga tables get the standard tenant policy;
+  operator dead-letter views run per-tenant (matching how admin routes already pass
+  tenant context). Cross-tenant operator dashboards are slice 7a's problem.
+* **At-least-once delivery** — process_pending marks processing before dispatch; a
+  crash between dispatch and mark_done re-delivers. Adapters must be idempotent
+  (idem_key is in every payload). Documented on the protocol.

--- a/src/office_hero/adapters/back_office/__init__.py
+++ b/src/office_hero/adapters/back_office/__init__.py
@@ -1,7 +1,21 @@
+"""Back-office adapter seam (ADR 056, Slice 24).
+
+``BackOfficeAdapter`` is the protocol every external-system integration
+implements; :class:`NativeAdapter` is the default binding where Office Hero
+itself is the system of record.  Concrete CRM adapters (ServiceTitan,
+PestPac, Jobber — slices 25-27) register in
+:mod:`office_hero.adapters.back_office.registry`.
+
+Delivery is at-least-once (the outbox re-delivers after a crash between
+dispatch and mark_done), so every adapter method MUST be idempotent — the
+outbox event's ``idem_key`` is available in each payload for deduplication
+against the external API.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 from uuid import UUID
 
 
@@ -50,42 +64,58 @@ class BackOfficeAdapter(Protocol):
 
 
 class NativeAdapter:
-    """Default back-office adapter using Office Hero as the system of record.
+    """Default back-office adapter: Office Hero is the system of record.
 
-    In the initial implementation the methods raise ``NotImplementedError``.
-    Later slices will refactor service/repository code to provide a concrete
-    implementation using the application's own database.
+    Reads delegate to the local repositories (tenant-scoped, defence-in-depth
+    per ADR 053).  Writes are acknowledgement no-ops: the domain services
+    already persisted the row before the outbox event fired, so "syncing to
+    the back office" is, natively, already done.  This keeps the seam's
+    calling convention identical to the external adapters in slices 25-27.
     """
 
+    name = "native"
+
+    def __init__(self, tenant_id: UUID, customer_repo: Any, job_repo: Any) -> None:
+        self._tenant_id = tenant_id
+        self._customer_repo = customer_repo
+        self._job_repo = job_repo
+
     async def health_check(self) -> bool:
-        # local DB should always be reachable when the application is running.
-        # external adapters may override to perform network calls.
+        """Local DB is reachable whenever the app is — always healthy."""
         return True
 
-    # The following are stubs; real behaviour will be added when the
-    # repository interfaces are available.  They exist primarily so the class
-    # satisfies the ``BackOfficeAdapter`` protocol.
+    # -- Customer operations -------------------------------------------------
 
     async def get_customer(self, id: UUID) -> Customer | None:
-        raise NotImplementedError
+        row = await self._customer_repo.get_by_id(id, self._tenant_id)
+        if row is None:
+            return None
+        return Customer(id=row.id, name=row.name)
 
     async def create_customer(self, customer: Customer) -> Customer:
-        raise NotImplementedError
+        # Row already exists locally (transactional outbox fires after the
+        # domain write) — acknowledge idempotently.
+        return customer
 
     async def update_customer(self, customer: Customer) -> Customer:
-        raise NotImplementedError
+        return customer
 
     async def delete_customer(self, id: UUID) -> None:
-        raise NotImplementedError
+        return None
+
+    # -- Job operations -------------------------------------------------------
 
     async def get_job(self, id: UUID) -> Job | None:
-        raise NotImplementedError
+        row = await self._job_repo.get_by_id(id, self._tenant_id)
+        if row is None:
+            return None
+        return Job(id=row.id, customer_id=row.customer_id)
 
     async def create_job(self, job: Job) -> Job:
-        raise NotImplementedError
+        return job
 
     async def update_job(self, job: Job) -> Job:
-        raise NotImplementedError
+        return job
 
     async def delete_job(self, id: UUID) -> None:
-        raise NotImplementedError
+        return None

--- a/src/office_hero/adapters/back_office/registry.py
+++ b/src/office_hero/adapters/back_office/registry.py
@@ -1,0 +1,56 @@
+"""Back-office adapter registry (Slice 24).
+
+Maps ``tenants.back_office_adapter`` values to adapter factories.  A factory
+takes ``(tenant_id, customer_repo, job_repo)`` and returns a
+:class:`~office_hero.adapters.back_office.BackOfficeAdapter`.
+
+Slices 25-27 add their adapters here::
+
+    register_adapter("servicetitan", ServiceTitanAdapter.from_tenant)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+from uuid import UUID
+
+from office_hero.adapters.back_office import BackOfficeAdapter, NativeAdapter
+
+AdapterFactory = Callable[[UUID, Any, Any], BackOfficeAdapter]
+
+
+class UnknownBackOfficeAdapterError(Exception):
+    """Raised when a tenant references an adapter name nobody registered."""
+
+    def __init__(self, name: str):
+        self.name = name
+        self.message = f"Unknown back-office adapter: {name!r}"
+        super().__init__(self.message)
+
+
+_REGISTRY: dict[str, AdapterFactory] = {}
+
+
+def register_adapter(name: str, factory: AdapterFactory) -> None:
+    """Register an adapter factory under ``name`` (idempotent overwrite)."""
+    _REGISTRY[name] = factory
+
+
+def get_adapter_factory(name: str) -> AdapterFactory:
+    """Resolve a factory or raise :class:`UnknownBackOfficeAdapterError`."""
+    try:
+        return _REGISTRY[name]
+    except KeyError as exc:
+        raise UnknownBackOfficeAdapterError(name) from exc
+
+
+def known_adapters() -> list[str]:
+    """Names usable in ``tenants.back_office_adapter`` (CHECK constraint mirrors this)."""
+    return sorted(_REGISTRY)
+
+
+register_adapter(
+    "native",
+    lambda tenant_id, customer_repo, job_repo: NativeAdapter(tenant_id, customer_repo, job_repo),
+)

--- a/src/office_hero/api/app.py
+++ b/src/office_hero/api/app.py
@@ -73,6 +73,7 @@ from office_hero.repositories.route_stop_repository import InMemoryRouteStopRepo
 from office_hero.repositories.vehicle_crew_repository import InMemoryVehicleCrewRepository
 from office_hero.repositories.vehicle_location_repository import InMemoryVehicleLocationRepository
 from office_hero.repositories.vehicle_repository import InMemoryVehicleRepository
+from office_hero.services.back_office_sync_service import BackOfficeSyncService
 from office_hero.services.contract_service import ContractService
 from office_hero.services.custom_field_templates import (
     registry as _template_registry_module,
@@ -211,7 +212,7 @@ def create_app(
 
     # Slice-11 default: in-memory contract repository sharing the job/customer/
     # location repos above so generated jobs land in the same store the /jobs
-    # routes read from.
+    # routes read from. The outbox wires the back-office sync seam (slice 24).
     if contract_service is None:
         contract_service = ContractService(
             repo=InMemoryContractRepository(),
@@ -220,8 +221,17 @@ def create_app(
             job_repo=_default_job_repo or InMemoryJobRepository(),
             audit=audit,
             template_registry=_template_registry_module,
+            outbox=outbox_repo,
         )
     set_contract_service(contract_service)
+
+    # Slice-24: back-office sync service draining the outbox through the
+    # tenant's adapter (native by default — see adapters/back_office/registry).
+    back_office_sync_service = BackOfficeSyncService(
+        outbox=outbox_repo,
+        customer_repo=cust_repo,
+        job_repo=_default_job_repo or InMemoryJobRepository(),
+    )
 
     # Slice-12 defaults: in-memory vehicle repos
     _default_v_repo: InMemoryVehicleRepository | None = None
@@ -352,6 +362,7 @@ def create_app(
     admin_router = create_admin_router(
         saga_service=saga_service,
         outbox_repo=outbox_repo,
+        sync_service_provider=lambda: back_office_sync_service,
     )
     application.include_router(admin_router, prefix="/admin", tags=["admin"])
     application.include_router(audit_router, prefix="/admin", tags=["admin"])

--- a/src/office_hero/api/routes/admin.py
+++ b/src/office_hero/api/routes/admin.py
@@ -70,6 +70,14 @@ class DeadLetterRetryResponse(BaseModel):
     message: str
 
 
+class OutboxProcessResponse(BaseModel):
+    """Counters from one outbox processing run."""
+
+    processed: int
+    failed: int
+    dead_lettered: int
+
+
 class SagaLogResponse(BaseModel):
     """Saga execution log response."""
 
@@ -134,6 +142,7 @@ def create_admin_router(
     *,
     saga_service: SagaService,
     outbox_repo: OutboxRepository,
+    sync_service_provider=None,
 ) -> APIRouter:
     """Factory that creates admin routes with injected dependencies (DI).
 
@@ -211,13 +220,11 @@ def create_admin_router(
         """
         tenant_id = getattr(request.state, "tenant_id", None)
 
-        event = outbox_repo.events.get(event_id)
+        # Protocol-friendly lookup (works for both the in-memory mock and the
+        # SQL repository — never reach into a private ``.events`` dict).
+        candidates = await outbox_repo.list_events(tenant_id=tenant_id)
+        event = next((e for e in candidates if str(e["id"]) == str(event_id)), None)
         if event is None:
-            raise HTTPException(status_code=404, detail=f"Event {event_id} not found")
-
-        # Tenant isolation: when a tenant_id is present on the request,
-        # the event must belong to that tenant.
-        if tenant_id is not None and str(event.get("tenant_id")) != str(tenant_id):
             raise HTTPException(status_code=404, detail=f"Event {event_id} not found")
 
         if event.get("status") != "dead":
@@ -241,6 +248,38 @@ def create_admin_router(
             status="pending",
             message="Event reset to pending for reprocessing",
         )
+
+    @router.post(
+        "/outbox/process",
+        response_model=OutboxProcessResponse,
+        summary="Process pending outbox events",
+        description=(
+            "Drain pending back-office sync events for the authenticated tenant "
+            "through its configured adapter (Operator only). Designed for cron."
+        ),
+        dependencies=[Depends(require_operator)],
+    )
+    async def process_outbox(
+        request: Request,
+        limit: int = Query(50, ge=1, le=500, description="Max events per run"),
+    ) -> OutboxProcessResponse:
+        """Run one back-office sync pass for the caller's tenant."""
+        if sync_service_provider is None:
+            raise HTTPException(status_code=503, detail="Back-office sync service not configured")
+        tenant_id = getattr(request.state, "tenant_id", None)
+        if tenant_id is None:
+            raise HTTPException(status_code=401, detail="Unauthorized")
+
+        service = sync_service_provider()
+        counters = await service.process_pending(
+            tenant_id if isinstance(tenant_id, UUID) else UUID(str(tenant_id)),
+            limit=limit,
+        )
+        logger.info(
+            "admin.outbox_processed",
+            extra={"tenant_id": str(tenant_id), **counters},
+        )
+        return OutboxProcessResponse(**counters)
 
     @router.get(
         "/sagas/{saga_id}/logs",

--- a/src/office_hero/models/__init__.py
+++ b/src/office_hero/models/__init__.py
@@ -16,7 +16,9 @@ from office_hero.models.contract import Contract  # noqa: F401, E402
 from office_hero.models.customer import Customer  # noqa: F401, E402
 from office_hero.models.job import Job  # noqa: F401, E402
 from office_hero.models.location import Location  # noqa: F401, E402
+from office_hero.models.outbox_event import OutboxEvent  # noqa: F401, E402
 from office_hero.models.route import Route, RouteStop  # noqa: F401, E402
+from office_hero.models.saga_log import SagaLog  # noqa: F401, E402
 from office_hero.models.tenant import Tenant  # noqa: F401, E402
 from office_hero.models.token import RefreshToken  # noqa: F401, E402
 from office_hero.models.user import User  # noqa: F401, E402

--- a/src/office_hero/models/outbox_event.py
+++ b/src/office_hero/models/outbox_event.py
@@ -1,0 +1,39 @@
+"""OutboxEvent ORM model — transactional outbox rows (ADR 056, Slice 24).
+
+Maps the ``outbox_events`` table created in migration 0001.  Ids are
+string-36 UUIDs (legacy table shape, preserved to avoid a type migration);
+the repository converts at the boundary.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import JSON, DateTime, Integer, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from office_hero.models import Base
+
+
+class OutboxEvent(Base):
+    """One reliably-deliverable event destined for a back-office adapter."""
+
+    __tablename__ = "outbox_events"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
+    tenant_id: Mapped[str] = mapped_column(String(36), nullable=False)
+    event_type: Mapped[str] = mapped_column(Text, nullable=False)
+    payload: Mapped[dict] = mapped_column(JSON, nullable=False)
+    idem_key: Mapped[str] = mapped_column(String(36), nullable=False)
+    # pending -> processing -> done | dead (dead can be retried back to pending)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="pending")
+    attempt_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    dead_letter_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+    processed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+    def __repr__(self) -> str:
+        return f"<OutboxEvent(id={self.id}, type={self.event_type}, status={self.status})>"

--- a/src/office_hero/models/saga_log.py
+++ b/src/office_hero/models/saga_log.py
@@ -1,0 +1,40 @@
+"""SagaLog ORM model — persisted saga execution state (ADR 056, Slice 24).
+
+Maps the ``saga_log`` table created in migration 0001.  Ids are string-36
+UUIDs (legacy table shape, preserved); the repository converts at the
+boundary.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import JSON, DateTime, Integer, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from office_hero.models import Base
+
+
+class SagaLog(Base):
+    """Execution record for one saga instance."""
+
+    __tablename__ = "saga_log"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
+    tenant_id: Mapped[str] = mapped_column(String(36), nullable=False)
+    saga_type: Mapped[str] = mapped_column(Text, nullable=False)
+    current_step: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # running | done | compensating | failed (see sagas.core.SagaStatus)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="running")
+    context: Mapped[dict] = mapped_column(JSON, nullable=False)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    def __repr__(self) -> str:
+        return f"<SagaLog(id={self.id}, type={self.saga_type}, status={self.status})>"

--- a/src/office_hero/models/tenant.py
+++ b/src/office_hero/models/tenant.py
@@ -22,6 +22,12 @@ class Tenant(Base):
     # Industry vertical — copied onto Job rows at creation time so historical
     # Jobs are unaffected by future industry changes (ADR 056 / design doc 012).
     industry: Mapped[str] = mapped_column(String(50), nullable=False, server_default="generic")
+    # Which back-office system this tenant syncs with (ADR 056 / design doc 024).
+    # 'native' = Office Hero is the system of record. Slices 25-27 add
+    # 'servicetitan' / 'pestpac' / 'jobber' via adapters.back_office.registry.
+    back_office_adapter: Mapped[str] = mapped_column(
+        String(50), nullable=False, server_default="native"
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/src/office_hero/repositories/mocks.py
+++ b/src/office_hero/repositories/mocks.py
@@ -159,6 +159,9 @@ class MockOutboxRepository:
     async def mark_processing(self, event_id: UUID) -> None:
         self.events[event_id]["status"] = "processing"
 
+    async def mark_pending(self, event_id: UUID) -> None:
+        self.events[event_id]["status"] = "pending"
+
     async def mark_done(self, event_id: UUID) -> None:
         now = datetime.now(UTC).isoformat()
         self.events[event_id]["status"] = "done"

--- a/src/office_hero/repositories/outbox_repository.py
+++ b/src/office_hero/repositories/outbox_repository.py
@@ -1,0 +1,153 @@
+"""SQL-backed outbox repository (ADR 056, Slice 24).
+
+Implements :class:`office_hero.repositories.protocols.OutboxRepository`
+against the ``outbox_events`` table.  The legacy table stores string-36
+ids; this repository accepts/returns :class:`uuid.UUID` (or str) and
+converts at the boundary so callers and the in-memory mock stay
+interchangeable.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from office_hero.models.outbox_event import OutboxEvent
+
+
+def _row_to_dict(row: OutboxEvent) -> dict[str, Any]:
+    """Project an ORM row onto the protocol's event-dict shape."""
+    return {
+        "id": UUID(row.id),
+        "tenant_id": UUID(row.tenant_id),
+        "event_type": row.event_type,
+        "payload": row.payload,
+        "idem_key": UUID(row.idem_key),
+        "status": row.status,
+        "attempt_count": row.attempt_count,
+        "dead_letter_reason": row.dead_letter_reason,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "processed_at": row.processed_at.isoformat() if row.processed_at else None,
+    }
+
+
+class SqlOutboxRepository:
+    """SQLAlchemy-backed concrete :class:`OutboxRepository` (ADR 058)."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        """Bind to an async SQLAlchemy session."""
+        self.session = session
+
+    async def _get(self, event_id: UUID) -> OutboxEvent:
+        row = await self.session.get(OutboxEvent, str(event_id))
+        if row is None:
+            raise KeyError(f"Outbox event {event_id} not found")
+        return row
+
+    async def create(
+        self,
+        tenant_id: UUID,
+        event_type: str,
+        payload: dict[str, Any],
+        idem_key: UUID,
+    ) -> dict[str, Any]:
+        """Insert a pending event; returns the protocol event dict."""
+        row = OutboxEvent(
+            tenant_id=str(tenant_id),
+            event_type=event_type,
+            payload=payload,
+            idem_key=str(idem_key),
+            status="pending",
+            attempt_count=0,
+        )
+        self.session.add(row)
+        await self.session.flush()
+        return _row_to_dict(row)
+
+    async def get_pending(self, tenant_id: UUID, limit: int = 10) -> list[dict[str, Any]]:
+        """Oldest-first pending events for a tenant."""
+        stmt = (
+            select(OutboxEvent)
+            .where(
+                OutboxEvent.tenant_id == str(tenant_id),
+                OutboxEvent.status == "pending",
+            )
+            .order_by(OutboxEvent.created_at.asc())
+            .limit(limit)
+        )
+        rows = (await self.session.execute(stmt)).scalars().all()
+        return [_row_to_dict(r) for r in rows]
+
+    async def mark_processing(self, event_id: UUID) -> None:
+        row = await self._get(event_id)
+        row.status = "processing"
+        await self.session.flush()
+
+    async def mark_pending(self, event_id: UUID) -> None:
+        row = await self._get(event_id)
+        row.status = "pending"
+        await self.session.flush()
+
+    async def mark_done(self, event_id: UUID) -> None:
+        row = await self._get(event_id)
+        row.status = "done"
+        row.processed_at = datetime.now(UTC).replace(tzinfo=None)
+        await self.session.flush()
+
+    async def mark_dead_letter(self, event_id: UUID, reason: str) -> None:
+        row = await self._get(event_id)
+        row.status = "dead"
+        row.dead_letter_reason = reason
+        row.processed_at = datetime.now(UTC).replace(tzinfo=None)
+        await self.session.flush()
+
+    async def increment_attempt_count(self, event_id: UUID) -> int:
+        await self.session.execute(
+            update(OutboxEvent)
+            .where(OutboxEvent.id == str(event_id))
+            .values(attempt_count=OutboxEvent.attempt_count + 1)
+        )
+        row = await self._get(event_id)
+        await self.session.refresh(row)
+        return row.attempt_count
+
+    async def get_dead_letters(self, tenant_id: UUID) -> list[dict[str, Any]]:
+        stmt = (
+            select(OutboxEvent)
+            .where(
+                OutboxEvent.tenant_id == str(tenant_id),
+                OutboxEvent.status == "dead",
+            )
+            .order_by(OutboxEvent.created_at.asc())
+        )
+        rows = (await self.session.execute(stmt)).scalars().all()
+        return [_row_to_dict(r) for r in rows]
+
+    async def retry_dead_letter(self, event_id: UUID) -> None:
+        row = await self._get(event_id)
+        row.status = "pending"
+        row.attempt_count = 0
+        row.dead_letter_reason = None
+        await self.session.flush()
+
+    async def list_events(
+        self,
+        *,
+        status: str | None = None,
+        tenant_id: UUID | str | None = None,
+        limit: int = 1000,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """Admin/operator enumeration with filters pushed down to SQL."""
+        stmt = select(OutboxEvent)
+        if status is not None:
+            stmt = stmt.where(OutboxEvent.status == status)
+        if tenant_id is not None:
+            stmt = stmt.where(OutboxEvent.tenant_id == str(tenant_id))
+        stmt = stmt.order_by(OutboxEvent.created_at.asc()).limit(limit).offset(offset)
+        rows = (await self.session.execute(stmt)).scalars().all()
+        return [_row_to_dict(r) for r in rows]

--- a/src/office_hero/repositories/protocols.py
+++ b/src/office_hero/repositories/protocols.py
@@ -88,6 +88,15 @@ class OutboxRepository(Protocol):
         """Mark an event as 'processing' to prevent concurrent handling."""
         ...
 
+    async def mark_pending(self, event_id: UUID) -> None:
+        """Return a failed event to 'pending' WITHOUT resetting attempt_count.
+
+        Used by the sync service to requeue an event for the next run while
+        preserving the exhaustion counter (contrast: retry_dead_letter resets
+        attempts because an operator explicitly intervened).
+        """
+        ...
+
     async def mark_done(self, event_id: UUID) -> None:
         """Mark an event as 'done' (status='done')."""
         ...

--- a/src/office_hero/repositories/saga_repository.py
+++ b/src/office_hero/repositories/saga_repository.py
@@ -1,0 +1,112 @@
+"""SQL-backed saga repository (ADR 056, Slice 24).
+
+Implements :class:`office_hero.repositories.protocols.SagaRepository`
+against the ``saga_log`` table.  String-36 ids are converted to/from
+:class:`uuid.UUID` at the boundary so callers and the in-memory mock stay
+interchangeable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from office_hero.models.saga_log import SagaLog
+from office_hero.sagas.core import SagaContext, SagaStatus
+
+
+def _row_to_context(row: SagaLog) -> SagaContext:
+    return SagaContext(
+        saga_id=UUID(row.id),
+        tenant_id=UUID(row.tenant_id),
+        saga_type=row.saga_type,
+        current_step=row.current_step,
+        status=SagaStatus(row.status),
+        context=dict(row.context or {}),
+        last_error=row.last_error,
+        created_at=row.created_at.isoformat() if row.created_at else None,
+        updated_at=row.updated_at.isoformat() if row.updated_at else None,
+    )
+
+
+class SqlSagaRepository:
+    """SQLAlchemy-backed concrete :class:`SagaRepository` (ADR 058)."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        """Bind to an async SQLAlchemy session."""
+        self.session = session
+
+    async def _get(self, saga_id: UUID) -> SagaLog:
+        row = await self.session.get(SagaLog, str(saga_id))
+        if row is None:
+            raise KeyError(f"Saga {saga_id} not found")
+        return row
+
+    async def create(self, tenant_id: UUID, saga_type: str, context: dict[str, Any]) -> SagaContext:
+        """Insert a running saga record; returns its SagaContext."""
+        row = SagaLog(
+            tenant_id=str(tenant_id),
+            saga_type=saga_type,
+            current_step=0,
+            status=SagaStatus.RUNNING.value,
+            context=context,
+        )
+        self.session.add(row)
+        await self.session.flush()
+        return _row_to_context(row)
+
+    async def get_by_id(self, saga_id: UUID) -> SagaContext | None:
+        row = await self.session.get(SagaLog, str(saga_id))
+        return _row_to_context(row) if row else None
+
+    async def get_by_type_and_context(
+        self,
+        tenant_id: UUID,
+        saga_type: str,
+        context_filter: dict[str, Any],
+    ) -> list[SagaContext]:
+        """Filter by type, then match context keys in Python.
+
+        JSON containment is Postgres-specific; the candidate set per
+        (tenant, type) is small, so in-process filtering keeps this portable
+        across sqlite (tests) and Postgres.
+        """
+        stmt = select(SagaLog).where(
+            SagaLog.tenant_id == str(tenant_id),
+            SagaLog.saga_type == saga_type,
+        )
+        rows = (await self.session.execute(stmt)).scalars().all()
+        contexts = [_row_to_context(r) for r in rows]
+        return [
+            c for c in contexts if all(c.context.get(k) == v for k, v in context_filter.items())
+        ]
+
+    async def update_status(
+        self,
+        saga_id: UUID,
+        new_status: SagaStatus,
+        context_update: dict[str, Any] | None = None,
+        error_msg: str | None = None,
+    ) -> SagaContext:
+        row = await self._get(saga_id)
+        row.status = new_status.value
+        if context_update:
+            # Reassign (not mutate) so SQLAlchemy detects the JSON change.
+            row.context = {**(row.context or {}), **context_update}
+        if error_msg:
+            row.last_error = error_msg
+        await self.session.flush()
+        # onupdate=func.now() expires updated_at on flush — refresh explicitly
+        # so reading it doesn't trigger sync lazy-load IO (MissingGreenlet).
+        await self.session.refresh(row)
+        return _row_to_context(row)
+
+    async def update_current_step(self, saga_id: UUID, step_number: int) -> SagaContext:
+        row = await self._get(saga_id)
+        row.current_step = step_number
+        await self.session.flush()
+        await self.session.refresh(row)
+        return _row_to_context(row)

--- a/src/office_hero/services/back_office_sync_service.py
+++ b/src/office_hero/services/back_office_sync_service.py
@@ -1,0 +1,139 @@
+"""BackOfficeSyncService — drains the transactional outbox through the
+tenant's back-office adapter (ADR 056, Slice 24).
+
+Trigger is manual/cron (``POST /admin/outbox/process``) in v1, same posture
+as contract job generation; a background poller can replace the trigger
+later without changing this service.
+
+Delivery is at-least-once: an event is marked ``processing`` before dispatch
+and ``done`` after, so a crash in between re-delivers on the next run.
+Adapters must therefore be idempotent (each payload carries ``idem_key``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from office_hero.adapters.back_office import Customer as BoCustomer
+from office_hero.adapters.back_office import Job as BoJob
+from office_hero.adapters.back_office.registry import (
+    UnknownBackOfficeAdapterError,
+    get_adapter_factory,
+)
+from office_hero.core.logging import get_logger
+from office_hero.repositories.protocols import OutboxRepository
+
+log = get_logger(__name__)
+
+# After this many failed attempts an event dead-letters; operators retry via
+# POST /admin/dead-letters/{id}/retry once the underlying cause is fixed.
+MAX_ATTEMPTS = 5
+
+
+class BackOfficeSyncService:
+    """Processes pending outbox events for one tenant at a time."""
+
+    def __init__(
+        self,
+        outbox: OutboxRepository,
+        customer_repo: Any,
+        job_repo: Any,
+        tenant_repo: Any = None,
+    ) -> None:
+        """``tenant_repo`` resolves the tenant's adapter name; None = native."""
+        self._outbox = outbox
+        self._customer_repo = customer_repo
+        self._job_repo = job_repo
+        self._tenant_repo = tenant_repo
+
+    async def _adapter_name(self, tenant_id: UUID) -> str:
+        if self._tenant_repo is None:
+            return "native"
+        tenant = await self._tenant_repo.get_by_id(tenant_id)
+        return getattr(tenant, "back_office_adapter", None) or "native"
+
+    async def _dispatch(self, adapter, event: dict[str, Any]) -> None:
+        """Route one event to the adapter method for its type."""
+        event_type: str = event["event_type"]
+        payload: dict[str, Any] = event["payload"]
+
+        if event_type in ("backoffice.customer.created", "backoffice.customer.updated"):
+            customer = BoCustomer(
+                id=UUID(str(payload["customer_id"])), name=payload.get("name", "")
+            )
+            if event_type.endswith("created"):
+                await adapter.create_customer(customer)
+            else:
+                await adapter.update_customer(customer)
+        elif event_type in (
+            "backoffice.job.created",
+            "backoffice.contract.created",
+        ):
+            # Contracts sync as their generated work definition; external
+            # systems that model contracts natively can override in their
+            # adapter (slices 25-27). Native acknowledges either way.
+            job = BoJob(
+                id=UUID(str(payload.get("job_id") or payload["contract_id"])),
+                customer_id=UUID(str(payload["customer_id"])),
+            )
+            await adapter.create_job(job)
+        else:
+            raise ValueError(f"No back-office handler for event type {event_type!r}")
+
+    async def process_pending(self, tenant_id: UUID, *, limit: int = 50) -> dict[str, int]:
+        """Process up to ``limit`` pending events; returns counters.
+
+        Failures increment ``attempt_count``; once it reaches
+        :data:`MAX_ATTEMPTS` the event dead-letters with the error recorded.
+        Until then the event returns to pending for the next run (the run
+        cadence provides natural backoff).
+        """
+        adapter_name = await self._adapter_name(tenant_id)
+        factory = get_adapter_factory(adapter_name)  # raises on unknown name
+        adapter = factory(tenant_id, self._customer_repo, self._job_repo)
+
+        processed = failed = dead = 0
+        for event in await self._outbox.get_pending(tenant_id, limit=limit):
+            event_id: UUID = event["id"]
+            await self._outbox.mark_processing(event_id)
+            try:
+                await self._dispatch(adapter, event)
+            except UnknownBackOfficeAdapterError:
+                raise
+            except Exception as exc:  # noqa: BLE001 — every failure mode dead-letters the same way
+                attempts = await self._outbox.increment_attempt_count(event_id)
+                if attempts >= MAX_ATTEMPTS:
+                    await self._outbox.mark_dead_letter(event_id, reason=str(exc))
+                    dead += 1
+                    log.warning(
+                        "backoffice.event_dead_lettered",
+                        event_id=str(event_id),
+                        event_type=event["event_type"],
+                        attempts=attempts,
+                        error=str(exc),
+                    )
+                else:
+                    await self._outbox.mark_pending(event_id)  # requeue, attempts kept
+                    failed += 1
+                    log.warning(
+                        "backoffice.event_failed",
+                        event_id=str(event_id),
+                        event_type=event["event_type"],
+                        attempts=attempts,
+                        error=str(exc),
+                    )
+            else:
+                await self._outbox.mark_done(event_id)
+                processed += 1
+
+        if processed or failed or dead:
+            log.info(
+                "backoffice.outbox_processed",
+                tenant_id=str(tenant_id),
+                adapter=adapter_name,
+                processed=processed,
+                failed=failed,
+                dead=dead,
+            )
+        return {"processed": processed, "failed": failed, "dead_lettered": dead}

--- a/src/office_hero/services/contract_service.py
+++ b/src/office_hero/services/contract_service.py
@@ -82,14 +82,22 @@ class ContractService:
         job_repo: JobRepositoryProtocol,
         audit: AuditPublisher,
         template_registry: Any,
+        outbox: Any = None,
     ) -> None:
-        """Inject the repository, cross-aggregate repos, audit publisher, and template registry."""
+        """Inject the repository, cross-aggregate repos, audit publisher, and template registry.
+
+        ``outbox`` (an :class:`~office_hero.repositories.protocols.OutboxRepository`)
+        enables the back-office sync seam: contract creation enqueues a
+        ``backoffice.contract.created`` event (ADR 056 transactional outbox).
+        None disables enqueueing (unit-test configuration).
+        """
         self.repo = repo
         self.customer_repo = customer_repo
         self.location_repo = location_repo
         self.job_repo = job_repo
         self.audit = audit
         self.template_registry = template_registry
+        self.outbox = outbox
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -186,6 +194,24 @@ class ContractService:
             tenant_id=tenant_id,
             user_id=user_id,
         )
+
+        # Back-office sync seam (ADR 056): enqueue in the same unit of work so
+        # the tenant's CRM adapter picks this up on the next outbox run.
+        if self.outbox is not None:
+            await self.outbox.create(
+                tenant_id,
+                event_type="backoffice.contract.created",
+                payload={
+                    "contract_id": str(contract.id),
+                    "customer_id": str(customer_id),
+                    "location_id": str(location_id),
+                    "title": title,
+                    "frequency": frequency,
+                    "start_date": start_date.isoformat(),
+                    "idem_key": str(contract.id),
+                },
+                idem_key=contract.id,
+            )
         return contract
 
     async def get(self, tenant_id: UUID, contract_id: UUID) -> Contract:

--- a/tests/api/test_admin_outbox_api.py
+++ b/tests/api/test_admin_outbox_api.py
@@ -1,0 +1,105 @@
+"""HTTP-layer tests for POST /admin/outbox/process (Slice 24)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from office_hero.api.app import create_app
+from tests.api.conftest import _TestAuthMiddleware
+
+
+def _operator_headers(tenant_id, user_id) -> dict[str, str]:
+    return {
+        "X-Test-Tenant-Id": str(tenant_id),
+        "X-Test-User-Id": str(user_id),
+        "X-Test-Role": "operator",
+        "X-Test-Permissions": "*",
+    }
+
+
+def _admin_headers(tenant_id, user_id) -> dict[str, str]:
+    """TenantAdmin — must NOT be able to trigger outbox processing."""
+    return {
+        "X-Test-Tenant-Id": str(tenant_id),
+        "X-Test-User-Id": str(user_id),
+        "X-Test-Role": "tenant_admin",
+        "X-Test-Permissions": "*",
+    }
+
+
+@pytest.fixture()
+def app():
+    application = create_app()
+    application.add_middleware(_TestAuthMiddleware)
+    return application
+
+
+@pytest.fixture()
+def client(app):
+    with TestClient(app) as c:
+        yield c
+
+
+def test_process_outbox_requires_operator_role(client):
+    resp = client.post(
+        "/admin/outbox/process",
+        headers=_admin_headers(uuid4(), uuid4()),
+    )
+    assert resp.status_code == 403
+
+
+def test_process_outbox_empty_returns_zero_counters(client):
+    resp = client.post(
+        "/admin/outbox/process",
+        headers=_operator_headers(uuid4(), uuid4()),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"processed": 0, "failed": 0, "dead_lettered": 0}
+
+
+def test_contract_creation_feeds_outbox_then_processing_drains_it(client):
+    """End-to-end seam: create customer+location+contract -> process -> done."""
+    tenant_id = uuid4()
+    user_id = uuid4()
+    headers = {
+        "X-Test-Tenant-Id": str(tenant_id),
+        "X-Test-User-Id": str(user_id),
+        "X-Test-Role": "operator",
+        "X-Test-Permissions": "*",
+    }
+
+    cust = client.post("/customers", json={"name": "Acme"}, headers=headers).json()
+    loc = client.post(
+        f"/customers/{cust['id']}/locations",
+        json={
+            "street": "1 Main St",
+            "city": "Austin",
+            "state": "TX",
+            "postal_code": "78701",
+        },
+        headers=headers,
+    ).json()
+
+    created = client.post(
+        "/contracts",
+        json={
+            "customer_id": cust["id"],
+            "location_id": loc["id"],
+            "title": "Quarterly pest plan",
+            "frequency": "quarterly",
+            "start_date": "2026-06-01",
+        },
+        headers=headers,
+    )
+    assert created.status_code == 201, created.text
+
+    resp = client.post("/admin/outbox/process", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["processed"] == 1
+
+    # Idempotent: the event is done; a second run drains nothing.
+    again = client.post("/admin/outbox/process", headers=headers)
+    assert again.json()["processed"] == 0

--- a/tests/integration/test_sql_outbox_saga_repos.py
+++ b/tests/integration/test_sql_outbox_saga_repos.py
@@ -1,0 +1,178 @@
+"""Integration tests for the SQL-backed outbox and saga repositories (Slice 24).
+
+Runs against in-memory SQLite (aiosqlite) — the repos are dialect-agnostic
+by design (string-36 ids, JSON columns, no Postgres-only operators).
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from office_hero.models import Base
+from office_hero.repositories.outbox_repository import SqlOutboxRepository
+from office_hero.repositories.saga_repository import SqlSagaRepository
+from office_hero.sagas.core import SagaStatus
+
+TENANT_A = uuid4()
+TENANT_B = uuid4()
+
+
+@pytest_asyncio.fixture
+async def session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def outbox(session) -> SqlOutboxRepository:
+    return SqlOutboxRepository(session)
+
+
+@pytest_asyncio.fixture
+async def saga_repo(session) -> SqlSagaRepository:
+    return SqlSagaRepository(session)
+
+
+# ---------------------------------------------------------------------------
+# Outbox lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def test_outbox_create_returns_pending_event(outbox):
+    idem = uuid4()
+    event = await outbox.create(
+        TENANT_A, "backoffice.contract.created", {"contract_id": "c1"}, idem
+    )
+    assert event["status"] == "pending"
+    assert event["attempt_count"] == 0
+    assert event["idem_key"] == idem
+    assert event["tenant_id"] == TENANT_A
+
+
+async def test_outbox_get_pending_is_tenant_scoped_and_ordered(outbox):
+    first = await outbox.create(TENANT_A, "e", {"n": 1}, uuid4())
+    second = await outbox.create(TENANT_A, "e", {"n": 2}, uuid4())
+    await outbox.create(TENANT_B, "e", {"n": 3}, uuid4())
+
+    pending = await outbox.get_pending(TENANT_A, limit=10)
+    assert [e["id"] for e in pending] == [first["id"], second["id"]]
+
+
+async def test_outbox_full_lifecycle_processing_done(outbox):
+    event = await outbox.create(TENANT_A, "e", {}, uuid4())
+    await outbox.mark_processing(event["id"])
+    assert await outbox.get_pending(TENANT_A) == []
+    await outbox.mark_done(event["id"])
+
+    done = await outbox.list_events(status="done", tenant_id=TENANT_A)
+    assert len(done) == 1
+    assert done[0]["processed_at"] is not None
+
+
+async def test_outbox_dead_letter_and_retry(outbox):
+    event = await outbox.create(TENANT_A, "e", {}, uuid4())
+    assert await outbox.increment_attempt_count(event["id"]) == 1
+    assert await outbox.increment_attempt_count(event["id"]) == 2
+    await outbox.mark_dead_letter(event["id"], reason="adapter exploded")
+
+    dead = await outbox.get_dead_letters(TENANT_A)
+    assert len(dead) == 1
+    assert dead[0]["dead_letter_reason"] == "adapter exploded"
+    assert dead[0]["attempt_count"] == 2
+
+    await outbox.retry_dead_letter(event["id"])
+    retried = await outbox.get_pending(TENANT_A)
+    assert len(retried) == 1
+    assert retried[0]["attempt_count"] == 0
+    assert retried[0]["dead_letter_reason"] is None
+
+
+async def test_outbox_mark_pending_keeps_attempt_count(outbox):
+    """The sync service requeues failures WITHOUT resetting the counter."""
+    event = await outbox.create(TENANT_A, "e", {}, uuid4())
+    await outbox.mark_processing(event["id"])
+    await outbox.increment_attempt_count(event["id"])
+    await outbox.mark_pending(event["id"])
+
+    pending = await outbox.get_pending(TENANT_A)
+    assert len(pending) == 1
+    assert pending[0]["attempt_count"] == 1
+
+
+async def test_outbox_list_events_filters(outbox):
+    done_event = await outbox.create(TENANT_A, "e", {}, uuid4())
+    await outbox.mark_done(done_event["id"])
+    await outbox.create(TENANT_A, "e", {}, uuid4())
+    await outbox.create(TENANT_B, "e", {}, uuid4())
+
+    assert len(await outbox.list_events(tenant_id=TENANT_A)) == 2
+    assert len(await outbox.list_events(status="pending", tenant_id=TENANT_A)) == 1
+    assert len(await outbox.list_events(status="pending")) == 2
+
+
+async def test_outbox_unknown_event_raises_key_error(outbox):
+    with pytest.raises(KeyError):
+        await outbox.mark_done(uuid4())
+
+
+# ---------------------------------------------------------------------------
+# Saga repository
+# ---------------------------------------------------------------------------
+
+
+async def test_saga_create_and_get_round_trip(saga_repo):
+    ctx = await saga_repo.create(TENANT_A, "contract_sync", {"contract_id": "c1"})
+    assert ctx.status is SagaStatus.RUNNING
+    assert ctx.current_step == 0
+
+    fetched = await saga_repo.get_by_id(ctx.saga_id)
+    assert fetched is not None
+    assert fetched.tenant_id == TENANT_A
+    assert fetched.context == {"contract_id": "c1"}
+
+
+async def test_saga_get_by_id_missing_returns_none(saga_repo):
+    assert await saga_repo.get_by_id(uuid4()) is None
+
+
+async def test_saga_update_status_merges_context_and_records_error(saga_repo):
+    ctx = await saga_repo.create(TENANT_A, "contract_sync", {"a": 1})
+
+    updated = await saga_repo.update_status(
+        ctx.saga_id,
+        SagaStatus.FAILED,
+        context_update={"b": 2},
+        error_msg="step 2 timed out",
+    )
+    assert updated.status is SagaStatus.FAILED
+    assert updated.context == {"a": 1, "b": 2}
+    assert updated.last_error == "step 2 timed out"
+
+
+async def test_saga_update_current_step(saga_repo):
+    ctx = await saga_repo.create(TENANT_A, "contract_sync", {})
+    updated = await saga_repo.update_current_step(ctx.saga_id, 3)
+    assert updated.current_step == 3
+
+
+async def test_saga_get_by_type_and_context_filters(saga_repo):
+    await saga_repo.create(TENANT_A, "contract_sync", {"contract_id": "c1"})
+    await saga_repo.create(TENANT_A, "contract_sync", {"contract_id": "c2"})
+    await saga_repo.create(TENANT_A, "job_sync", {"contract_id": "c1"})
+    await saga_repo.create(TENANT_B, "contract_sync", {"contract_id": "c1"})
+
+    matches = await saga_repo.get_by_type_and_context(
+        TENANT_A, "contract_sync", {"contract_id": "c1"}
+    )
+    assert len(matches) == 1
+    assert matches[0].context["contract_id"] == "c1"

--- a/tests/test_backoffice_adapter.py
+++ b/tests/test_backoffice_adapter.py
@@ -40,16 +40,24 @@ class DummyAdapter:
         pass
 
 
+def _native_adapter() -> NativeAdapter:
+    """NativeAdapter is tenant-scoped since slice 24 (see test_native_adapter.py)."""
+    from office_hero.repositories.customer_repository import InMemoryCustomerRepository
+    from office_hero.repositories.job_repository import InMemoryJobRepository
+
+    return NativeAdapter(uuid4(), InMemoryCustomerRepository(), InMemoryJobRepository())
+
+
 @pytest.mark.asyncio
 async def test_protocol_runtime_checkable():
     """The protocol should be checkable at runtime and accept conforming objects."""
     assert isinstance(DummyAdapter(), BackOfficeAdapter)
-    assert isinstance(NativeAdapter(), BackOfficeAdapter)
+    assert isinstance(_native_adapter(), BackOfficeAdapter)
 
 
 @pytest.mark.asyncio
 async def test_health_check_default():
-    adapter = NativeAdapter()
+    adapter = _native_adapter()
     assert await adapter.health_check() is True
 
 

--- a/tests/unit/test_back_office_sync_service.py
+++ b/tests/unit/test_back_office_sync_service.py
@@ -1,0 +1,148 @@
+"""Unit tests for BackOfficeSyncService — outbox draining + dead-lettering (Slice 24)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from office_hero.repositories.customer_repository import InMemoryCustomerRepository
+from office_hero.repositories.job_repository import InMemoryJobRepository
+from office_hero.repositories.mocks import MockOutboxRepository
+from office_hero.services.back_office_sync_service import MAX_ATTEMPTS, BackOfficeSyncService
+
+TENANT_A = uuid4()
+TENANT_B = uuid4()
+
+
+@pytest.fixture()
+def outbox() -> MockOutboxRepository:
+    return MockOutboxRepository()
+
+
+@pytest.fixture()
+def svc(outbox) -> BackOfficeSyncService:
+    return BackOfficeSyncService(
+        outbox=outbox,
+        customer_repo=InMemoryCustomerRepository(),
+        job_repo=InMemoryJobRepository(),
+    )
+
+
+async def _enqueue_contract_event(outbox, *, tenant_id=TENANT_A) -> dict:
+    contract_id = uuid4()
+    return await outbox.create(
+        tenant_id,
+        event_type="backoffice.contract.created",
+        payload={
+            "contract_id": str(contract_id),
+            "customer_id": str(uuid4()),
+            "title": "Quarterly plan",
+            "idem_key": str(contract_id),
+        },
+        idem_key=contract_id,
+    )
+
+
+async def test_process_pending_marks_contract_event_done(svc, outbox):
+    event = await _enqueue_contract_event(outbox)
+
+    counters = await svc.process_pending(TENANT_A)
+
+    assert counters == {"processed": 1, "failed": 0, "dead_lettered": 0}
+    assert outbox.events[event["id"]]["status"] == "done"
+    assert outbox.events[event["id"]]["processed_at"] is not None
+
+
+async def test_process_pending_scopes_to_tenant(svc, outbox):
+    event = await _enqueue_contract_event(outbox, tenant_id=TENANT_B)
+
+    counters = await svc.process_pending(TENANT_A)
+
+    assert counters["processed"] == 0
+    assert outbox.events[event["id"]]["status"] == "pending"
+
+
+async def test_unknown_event_type_dead_letters_after_max_attempts(svc, outbox):
+    event = await outbox.create(
+        TENANT_A,
+        event_type="backoffice.unsupported.thing",
+        payload={"idem_key": str(uuid4())},
+        idem_key=uuid4(),
+    )
+
+    for run in range(1, MAX_ATTEMPTS + 1):
+        counters = await svc.process_pending(TENANT_A)
+        if run < MAX_ATTEMPTS:
+            assert counters["failed"] == 1
+            assert outbox.events[event["id"]]["status"] == "pending"
+            assert outbox.events[event["id"]]["attempt_count"] == run
+        else:
+            assert counters["dead_lettered"] == 1
+
+    row = outbox.events[event["id"]]
+    assert row["status"] == "dead"
+    assert "No back-office handler" in row["dead_letter_reason"]
+
+    # Dead events are not picked up again.
+    assert (await svc.process_pending(TENANT_A))["processed"] == 0
+
+
+async def test_operator_retry_resets_attempts_and_reprocesses(outbox):
+    """A retried dead-letter goes through the full attempt budget again."""
+
+    class _ExplodingAdapterService(BackOfficeSyncService):
+        pass
+
+    event = await outbox.create(
+        TENANT_A,
+        event_type="backoffice.unsupported.thing",
+        payload={"idem_key": str(uuid4())},
+        idem_key=uuid4(),
+    )
+    svc = _ExplodingAdapterService(
+        outbox=outbox,
+        customer_repo=InMemoryCustomerRepository(),
+        job_repo=InMemoryJobRepository(),
+    )
+    for _ in range(MAX_ATTEMPTS):
+        await svc.process_pending(TENANT_A)
+    assert outbox.events[event["id"]]["status"] == "dead"
+
+    await outbox.retry_dead_letter(event["id"])
+    assert outbox.events[event["id"]]["status"] == "pending"
+    assert outbox.events[event["id"]]["attempt_count"] == 0
+
+
+async def test_customer_created_event_routes_to_adapter(svc, outbox):
+    event = await outbox.create(
+        TENANT_A,
+        event_type="backoffice.customer.created",
+        payload={"customer_id": str(uuid4()), "name": "Acme", "idem_key": str(uuid4())},
+        idem_key=uuid4(),
+    )
+
+    counters = await svc.process_pending(TENANT_A)
+
+    assert counters["processed"] == 1
+    assert outbox.events[event["id"]]["status"] == "done"
+
+
+async def test_tenant_repo_resolves_adapter_name(outbox):
+    """The tenant's back_office_adapter column drives registry resolution."""
+
+    class _Tenant:
+        back_office_adapter = "native"
+
+    class _TenantRepo:
+        async def get_by_id(self, tenant_id):
+            return _Tenant()
+
+    svc = BackOfficeSyncService(
+        outbox=outbox,
+        customer_repo=InMemoryCustomerRepository(),
+        job_repo=InMemoryJobRepository(),
+        tenant_repo=_TenantRepo(),
+    )
+    await _enqueue_contract_event(outbox)
+    assert (await svc.process_pending(TENANT_A))["processed"] == 1

--- a/tests/unit/test_contract_service.py
+++ b/tests/unit/test_contract_service.py
@@ -122,6 +122,34 @@ async def test_create_contract_sets_next_due_to_start_date_and_audits(
     assert any(e.event_type == "contract.created" for e in audit.events)
 
 
+async def test_create_contract_enqueues_back_office_outbox_event(
+    contract_repo, cust_repo, loc_repo, job_repo, audit
+):
+    """The transactional-outbox seam (slice 24): create -> sync event enqueued."""
+    from office_hero.repositories.mocks import MockOutboxRepository
+
+    outbox = MockOutboxRepository()
+    svc_with_outbox = ContractService(
+        repo=contract_repo,
+        customer_repo=cust_repo,
+        location_repo=loc_repo,
+        job_repo=job_repo,
+        audit=audit,
+        template_registry=template_registry,
+        outbox=outbox,
+    )
+    cust, loc = await _seed_customer_and_location(cust_repo, loc_repo)
+    contract = await _create_contract(svc_with_outbox, cust, loc)
+
+    events = list(outbox.events.values())
+    assert len(events) == 1
+    event = events[0]
+    assert event["event_type"] == "backoffice.contract.created"
+    assert event["idem_key"] == contract.id
+    assert event["payload"]["contract_id"] == str(contract.id)
+    assert event["status"] == "pending"
+
+
 async def test_create_contract_unknown_customer_raises_not_found(svc, cust_repo, loc_repo):
     cust, loc = await _seed_customer_and_location(cust_repo, loc_repo)
     with pytest.raises(CustomerNotFoundError):

--- a/tests/unit/test_native_adapter.py
+++ b/tests/unit/test_native_adapter.py
@@ -1,0 +1,95 @@
+"""Unit tests for the NativeAdapter + back-office adapter registry (Slice 24)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from office_hero.adapters.back_office import BackOfficeAdapter, Customer, Job, NativeAdapter
+from office_hero.adapters.back_office.registry import (
+    UnknownBackOfficeAdapterError,
+    get_adapter_factory,
+    known_adapters,
+)
+from office_hero.repositories.customer_repository import InMemoryCustomerRepository
+from office_hero.repositories.job_repository import InMemoryJobRepository
+
+TENANT_A = uuid4()
+TENANT_B = uuid4()
+USER_A = uuid4()
+
+
+@pytest.fixture()
+def cust_repo() -> InMemoryCustomerRepository:
+    return InMemoryCustomerRepository()
+
+
+@pytest.fixture()
+def job_repo() -> InMemoryJobRepository:
+    return InMemoryJobRepository()
+
+
+@pytest.fixture()
+def adapter(cust_repo, job_repo) -> NativeAdapter:
+    return NativeAdapter(TENANT_A, cust_repo, job_repo)
+
+
+async def test_native_adapter_satisfies_protocol(adapter):
+    assert isinstance(adapter, BackOfficeAdapter)
+
+
+async def test_health_check_true(adapter):
+    assert await adapter.health_check() is True
+
+
+async def test_get_customer_returns_local_row(adapter, cust_repo):
+    row = await cust_repo.create(TENANT_A, name="Acme Plumbing")
+    result = await adapter.get_customer(row.id)
+    assert result == Customer(id=row.id, name="Acme Plumbing")
+
+
+async def test_get_customer_cross_tenant_returns_none(adapter, cust_repo):
+    """Tenant B's customer is invisible through tenant A's adapter."""
+    row = await cust_repo.create(TENANT_B, name="Other Co")
+    assert await adapter.get_customer(row.id) is None
+
+
+async def test_get_job_returns_local_row(adapter, job_repo):
+    row = await job_repo.create(
+        TENANT_A,
+        customer_id=uuid4(),
+        location_id=uuid4(),
+        industry="plumbing",
+        title="Fix pipe",
+        created_by_user_id=USER_A,
+    )
+    result = await adapter.get_job(row.id)
+    assert result == Job(id=row.id, customer_id=row.customer_id)
+
+
+async def test_create_and_update_are_idempotent_acknowledgements(adapter):
+    """Native writes acknowledge — Office Hero already persisted the row."""
+    customer = Customer(id=uuid4(), name="Acme")
+    job = Job(id=uuid4(), customer_id=customer.id)
+    assert await adapter.create_customer(customer) == customer
+    assert await adapter.update_customer(customer) == customer
+    assert await adapter.create_job(job) == job
+    assert await adapter.update_job(job) == job
+    assert await adapter.delete_customer(customer.id) is None
+    assert await adapter.delete_job(job.id) is None
+
+
+def test_registry_resolves_native(cust_repo, job_repo):
+    factory = get_adapter_factory("native")
+    adapter = factory(TENANT_A, cust_repo, job_repo)
+    assert isinstance(adapter, NativeAdapter)
+
+
+def test_registry_unknown_name_raises():
+    with pytest.raises(UnknownBackOfficeAdapterError):
+        get_adapter_factory("salesforce")
+
+
+def test_known_adapters_lists_native():
+    assert "native" in known_adapters()


### PR DESCRIPTION
## Summary

Implements **Slice 24** — the explicit, tested seam for 'works with the customer's existing CRM'. Stacked on #110.

- **NativeAdapter implemented for real**: tenant-scoped reads via local repos, idempotent write acknowledgements (Office Hero is the system of record); no more `NotImplementedError`
- **Adapter registry** keyed by new `tenants.back_office_adapter` column (migration 0012, default `native`) — ServiceTitan/PestPac/Jobber (slices 25–27) drop in here
- **Persistent outbox/saga**: `SqlOutboxRepository` + `SqlSagaRepository` implementing the existing protocols against the legacy tables; migration 0012 adds `dead_letter_reason`/`last_error`, polling index, RLS policies
- **Transactional outbox wired**: contract creation enqueues `backoffice.contract.created`; `BackOfficeSyncService` drains pending events through the tenant's adapter with attempt counting and dead-lettering after 5 tries (`mark_pending` keeps the exhaustion counter; operator retry resets it)
- **`POST /admin/outbox/process`** (Operator-only, cron-ready); dead-letter retry endpoint now protocol-clean (was reaching into the mock's `.events` dict)

31 new tests; full suite **483 passed**. Design doc: `024-slice.backoffice-adapter.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)