### PR TITLE
chore: repo optimization pass 2 — request-helper extraction, N+1 fix, indexes, shared StatusBadges

### DIFF
--- a/alembic/versions/0014_performance_indexes.py
+++ b/alembic/versions/0014_performance_indexes.py
@@ -1,0 +1,42 @@
+"""Composite indexes for the dispatch crew-lookup and contract generation queries
+
+Revision ID: 0014_performance_indexes
+Revises: 0013_archived_indexes
+Create Date: 2026-06-13 00:00:00.000000
+
+* ``vehicle_crews`` — ``get_for_vehicle_date`` filters on
+  ``(tenant_id, vehicle_id, work_date)`` and runs on every dispatch commit,
+  reassignment, and emergency dispatch. The existing
+  ``idx_vehicle_crew_tenant_date(tenant_id, work_date)`` doesn't cover the
+  ``vehicle_id`` predicate; add the three-column composite.
+* ``contracts`` — ``list_due`` filters on ``(tenant_id, status='active',
+  next_due <= as_of)`` and orders by ``next_due``. The separate
+  ``(tenant_id, status)`` and ``(tenant_id, next_due)`` indexes each serve only
+  part of it; a ``(tenant_id, status, next_due)`` composite serves the whole
+  generation-pass query in one scan.
+"""
+
+from alembic import op
+
+revision = "0014_performance_indexes"
+down_revision = "0013_archived_indexes"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "idx_vehicle_crew_tenant_vehicle_date",
+        "vehicle_crews",
+        ["tenant_id", "vehicle_id", "work_date"],
+    )
+    op.create_index(
+        "idx_contracts_tenant_status_next_due",
+        "contracts",
+        ["tenant_id", "status", "next_due"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_contracts_tenant_status_next_due", table_name="contracts")
+    op.drop_index("idx_vehicle_crew_tenant_vehicle_date", table_name="vehicle_crews")

--- a/apps/admin-web/src/components/StatusBadges.tsx
+++ b/apps/admin-web/src/components/StatusBadges.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import type { ContractStatus, JobStatus, RouteStatus } from '../api';
+
+/**
+ * Shared status-badge components — one per status enum. Each renders the same
+ * pill markup; only the colour/label maps differ. Extracted from the
+ * near-identical local StatusBadge definitions that lived in JobsPage,
+ * ContractsPage and RoutesPage.
+ */
+
+const PILL =
+  'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium';
+const FALLBACK = 'bg-neutral-100 text-neutral-600';
+
+function Badge({ label, color }: { label: string; color: string }) {
+  return <span className={`${PILL} ${color}`}>{label}</span>;
+}
+
+const JOB_COLORS: Record<JobStatus, string> = {
+  pending:     'bg-amber-100 text-amber-800',
+  scheduled:   'bg-blue-100 text-blue-800',
+  in_progress: 'bg-indigo-100 text-indigo-800',
+  completed:   'bg-green-100 text-green-800',
+  cancelled:   'bg-neutral-100 text-neutral-500',
+};
+const JOB_LABELS: Record<JobStatus, string> = {
+  pending:     'Pending',
+  scheduled:   'Scheduled',
+  in_progress: 'In Progress',
+  completed:   'Completed',
+  cancelled:   'Cancelled',
+};
+
+export function JobStatusBadge({ status }: { status: JobStatus }) {
+  return <Badge label={JOB_LABELS[status] ?? status} color={JOB_COLORS[status] ?? FALLBACK} />;
+}
+
+const CONTRACT_COLORS: Record<ContractStatus, string> = {
+  active: 'bg-green-100 text-green-800',
+  paused: 'bg-amber-100 text-amber-800',
+  ended:  'bg-neutral-100 text-neutral-500',
+};
+const CONTRACT_LABELS: Record<ContractStatus, string> = {
+  active: 'Active',
+  paused: 'Paused',
+  ended:  'Ended',
+};
+
+export function ContractStatusBadge({ status }: { status: ContractStatus }) {
+  return (
+    <Badge label={CONTRACT_LABELS[status] ?? status} color={CONTRACT_COLORS[status] ?? FALLBACK} />
+  );
+}
+
+const ROUTE_COLORS: Record<RouteStatus, string> = {
+  draft:       'bg-neutral-100 text-neutral-600',
+  committed:   'bg-blue-100 text-blue-800',
+  in_progress: 'bg-indigo-100 text-indigo-800',
+  complete:    'bg-green-100 text-green-800',
+  cancelled:   'bg-neutral-100 text-neutral-500',
+};
+const ROUTE_LABELS: Record<RouteStatus, string> = {
+  draft:       'Draft',
+  committed:   'Committed',
+  in_progress: 'In Progress',
+  complete:    'Complete',
+  cancelled:   'Cancelled',
+};
+
+export function RouteStatusBadge({ status }: { status: RouteStatus }) {
+  return <Badge label={ROUTE_LABELS[status] ?? status} color={ROUTE_COLORS[status] ?? FALLBACK} />;
+}

--- a/apps/admin-web/src/pages/ContractsPage.tsx
+++ b/apps/admin-web/src/pages/ContractsPage.tsx
@@ -25,6 +25,7 @@ import { Button } from '../components/ui/Button';
 import { Input } from '../components/ui/Input';
 import { Modal } from '../components/ui/Modal';
 import { Skeleton } from '../components/ui/Skeleton';
+import { ContractStatusBadge } from '../components/StatusBadges';
 import {
   Table,
   TableBody,
@@ -34,18 +35,6 @@ import {
   TableRow,
 } from '../components/ui/Table';
 
-const STATUS_COLORS: Record<ContractStatus, string> = {
-  active: 'bg-green-100 text-green-800',
-  paused: 'bg-amber-100 text-amber-800',
-  ended:  'bg-neutral-100 text-neutral-500',
-};
-
-const STATUS_LABELS: Record<ContractStatus, string> = {
-  active: 'Active',
-  paused: 'Paused',
-  ended:  'Ended',
-};
-
 const FREQUENCY_LABELS: Record<ContractFrequency, string> = {
   weekly:     'Weekly',
   biweekly:   'Every 2 weeks',
@@ -54,16 +43,6 @@ const FREQUENCY_LABELS: Record<ContractFrequency, string> = {
   semiannual: 'Twice a year',
   annual:     'Yearly',
 };
-
-function StatusBadge({ status }: { status: ContractStatus }) {
-  return (
-    <span
-      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${STATUS_COLORS[status] ?? 'bg-neutral-100 text-neutral-600'}`}
-    >
-      {STATUS_LABELS[status] ?? status}
-    </span>
-  );
-}
 
 const STATUS_FILTER_OPTIONS: Array<{ value: ContractStatus | ''; label: string }> = [
   { value: '',       label: 'All statuses' },
@@ -587,7 +566,7 @@ export const ContractsPage: React.FC = () => {
               <TableRow key={contract.id} data-testid="contract-row">
                 <TableCell className="font-medium">{contract.title}</TableCell>
                 <TableCell>
-                  <StatusBadge status={contract.status} />
+                  <ContractStatusBadge status={contract.status} />
                 </TableCell>
                 <TableCell className="text-neutral-500">
                   {FREQUENCY_LABELS[contract.frequency] ?? contract.frequency}

--- a/apps/admin-web/src/pages/JobsPage.tsx
+++ b/apps/admin-web/src/pages/JobsPage.tsx
@@ -25,6 +25,7 @@ import { Button } from '../components/ui/Button';
 import { Input } from '../components/ui/Input';
 import { Modal } from '../components/ui/Modal';
 import { Skeleton } from '../components/ui/Skeleton';
+import { JobStatusBadge } from '../components/StatusBadges';
 import {
   Table,
   TableBody,
@@ -33,32 +34,6 @@ import {
   TableHeader,
   TableRow,
 } from '../components/ui/Table';
-
-const STATUS_COLORS: Record<JobStatus, string> = {
-  pending:     'bg-amber-100 text-amber-800',
-  scheduled:   'bg-blue-100 text-blue-800',
-  in_progress: 'bg-indigo-100 text-indigo-800',
-  completed:   'bg-green-100 text-green-800',
-  cancelled:   'bg-neutral-100 text-neutral-500',
-};
-
-const STATUS_LABELS: Record<JobStatus, string> = {
-  pending:     'Pending',
-  scheduled:   'Scheduled',
-  in_progress: 'In Progress',
-  completed:   'Completed',
-  cancelled:   'Cancelled',
-};
-
-function StatusBadge({ status }: { status: JobStatus }) {
-  return (
-    <span
-      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${STATUS_COLORS[status] ?? 'bg-neutral-100 text-neutral-600'}`}
-    >
-      {STATUS_LABELS[status] ?? status}
-    </span>
-  );
-}
 
 const STATUS_FILTER_OPTIONS: Array<{ value: JobStatus | ''; label: string }> = [
   { value: '',            label: 'All statuses' },
@@ -669,7 +644,7 @@ export const JobsPage: React.FC = () => {
               <TableRow key={job.id} data-testid="job-row">
                 <TableCell className="font-medium">{job.title}</TableCell>
                 <TableCell>
-                  <StatusBadge status={job.status} />
+                  <JobStatusBadge status={job.status} />
                 </TableCell>
                 <TableCell className="text-neutral-500">{job.service_type ?? '—'}</TableCell>
                 <TableCell className="text-neutral-500">

--- a/apps/admin-web/src/pages/RoutesPage.tsx
+++ b/apps/admin-web/src/pages/RoutesPage.tsx
@@ -3,7 +3,6 @@ import { listVehicles, type AdminVehicle } from '@office-hero/api-client';
 import {
   type ApiError,
   type RouteRead,
-  type RouteStatus,
   type RouteStopStatus,
   cancelRouteApi,
   listRoutesApi,
@@ -17,22 +16,7 @@ import { Card, CardContent, CardHeader } from '../components/ui/Card';
 import { Input } from '../components/ui/Input';
 import { Modal } from '../components/ui/Modal';
 import { Skeleton } from '../components/ui/Skeleton';
-
-const ROUTE_STATUS_COLORS: Record<RouteStatus, string> = {
-  draft:       'bg-neutral-100 text-neutral-600',
-  committed:   'bg-blue-100 text-blue-800',
-  in_progress: 'bg-indigo-100 text-indigo-800',
-  complete:    'bg-green-100 text-green-800',
-  cancelled:   'bg-neutral-100 text-neutral-500',
-};
-
-const ROUTE_STATUS_LABELS: Record<RouteStatus, string> = {
-  draft:       'Draft',
-  committed:   'Committed',
-  in_progress: 'In Progress',
-  complete:    'Complete',
-  cancelled:   'Cancelled',
-};
+import { RouteStatusBadge } from '../components/StatusBadges';
 
 const STOP_STATUS_COLORS: Record<RouteStopStatus, string> = {
   pending:  'bg-amber-100 text-amber-800',
@@ -40,16 +24,6 @@ const STOP_STATUS_COLORS: Record<RouteStopStatus, string> = {
   complete: 'bg-green-100 text-green-800',
   skipped:  'bg-neutral-100 text-neutral-500',
 };
-
-function StatusBadge({ status }: { status: RouteStatus }) {
-  return (
-    <span
-      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${ROUTE_STATUS_COLORS[status] ?? 'bg-neutral-100 text-neutral-600'}`}
-    >
-      {ROUTE_STATUS_LABELS[status] ?? status}
-    </span>
-  );
-}
 
 function todayISODate(): string {
   const d = new Date();
@@ -283,7 +257,7 @@ function RouteCard({
         <div>
           <div className="flex items-center gap-2">
             <span className="font-semibold text-neutral-900">{vehicleName}</span>
-            <StatusBadge status={route.status} />
+            <RouteStatusBadge status={route.status} />
           </div>
           <p className="mt-0.5 text-sm text-neutral-500">
             {stops.length} stop{stops.length === 1 ? '' : 's'} ·{' '}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-hero-mobile",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-hero-mobile",
-  "version": "0.1.29",
+  "version": "0.1.31",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/src/office_hero/api/request_context.py
+++ b/src/office_hero/api/request_context.py
@@ -1,0 +1,46 @@
+"""Shared request-context helpers for route handlers.
+
+Every ``api/routes/*.py`` module previously defined identical local
+``_tenant_id`` / ``_user_id`` helpers that read auth context off
+``request.state`` (populated by the JWT / test-auth middleware).  These are
+the single source of truth so the auth-extraction logic lives in one place.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import Request, status
+from fastapi.exceptions import HTTPException
+
+
+def _coerce_uuid(raw: object) -> UUID:
+    return raw if isinstance(raw, UUID) else UUID(str(raw))
+
+
+def require_tenant_id(request: Request) -> UUID:
+    """Return the request's tenant_id, or raise 401 if unauthenticated."""
+    raw = getattr(request.state, "tenant_id", None)
+    if not raw:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+    return _coerce_uuid(raw)
+
+
+def require_user_id(request: Request) -> UUID:
+    """Return the request's user_id (for audit attribution), or raise 401."""
+    raw = getattr(request.state, "user_id", None)
+    if not raw:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+    return _coerce_uuid(raw)
+
+
+def optional_user_id(request: Request) -> UUID | None:
+    """Return the request's user_id or None when absent (no raise).
+
+    Used where user attribution is best-effort (e.g. the dispatch route, which
+    passes the id through to services that tolerate ``None``).
+    """
+    raw = getattr(request.state, "user_id", None)
+    if not raw:
+        return None
+    return _coerce_uuid(raw)

--- a/src/office_hero/api/routes/contracts.py
+++ b/src/office_hero/api/routes/contracts.py
@@ -21,6 +21,8 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, sta
 
 from office_hero.api.deps import require_permission
 from office_hero.api.limiter import limiter
+from office_hero.api.request_context import require_tenant_id as _tenant_id
+from office_hero.api.request_context import require_user_id as _user_id
 from office_hero.api.schemas.contract import (
     ContractCreate,
     ContractEndRequest,
@@ -47,22 +49,6 @@ log = get_logger(__name__)
 require_contracts_read = require_permission("contracts:read")
 require_contracts_write = require_permission("contracts:write")
 require_jobs_write = require_permission("jobs:write")
-
-
-def _tenant_id(request: Request) -> UUID:
-    """Extract tenant_id from request.state; raise 401 if missing."""
-    raw = getattr(request.state, "tenant_id", None)
-    if not raw:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
-    return raw if isinstance(raw, UUID) else UUID(str(raw))
-
-
-def _user_id(request: Request) -> UUID:
-    """Extract user_id from request.state for audit attribution."""
-    raw = getattr(request.state, "user_id", None)
-    if not raw:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
-    return raw if isinstance(raw, UUID) else UUID(str(raw))
 
 
 def create_contract_router(*, service_provider) -> APIRouter:

--- a/src/office_hero/api/routes/customers.py
+++ b/src/office_hero/api/routes/customers.py
@@ -15,6 +15,8 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, sta
 
 from office_hero.api.deps import require_permission, require_role
 from office_hero.api.limiter import limiter
+from office_hero.api.request_context import require_tenant_id as _tenant_id
+from office_hero.api.request_context import require_user_id as _user_id
 from office_hero.api.schemas.customer import (
     CustomerCreate,
     CustomerList,
@@ -34,22 +36,6 @@ log = get_logger(__name__)
 require_customers_read = require_permission("customers:read")
 require_customers_write = require_permission("customers:write")
 require_customer_admin = require_role([Role.TenantAdmin, Role.Operator, Role.OperatorStaff])
-
-
-def _tenant_id(request: Request) -> UUID:
-    """Extract tenant_id from request.state; raise 401 if missing."""
-    raw = getattr(request.state, "tenant_id", None)
-    if not raw:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
-    return raw if isinstance(raw, UUID) else UUID(str(raw))
-
-
-def _user_id(request: Request) -> UUID:
-    """Extract user_id from request.state for audit attribution."""
-    raw = getattr(request.state, "user_id", None)
-    if not raw:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
-    return raw if isinstance(raw, UUID) else UUID(str(raw))
 
 
 def create_customer_router(

--- a/src/office_hero/api/routes/dispatch.py
+++ b/src/office_hero/api/routes/dispatch.py
@@ -10,6 +10,8 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Request, status
 
 from office_hero.api.deps import require_permission
 from office_hero.api.limiter import limiter
+from office_hero.api.request_context import optional_user_id as _user_id
+from office_hero.api.request_context import require_tenant_id as _tenant_id
 from office_hero.api.schemas.dispatch import JobDispatchRequest, JobDispatchResponse
 from office_hero.api.schemas.route import EmergencyDispatchRequest, RouteRead
 from office_hero.core.exceptions import (
@@ -28,20 +30,6 @@ require_job_write = require_permission("job:write")
 require_vehicle_read = require_permission("vehicle:read")
 require_jobs_dispatch = require_permission("jobs:dispatch")
 require_route_write = require_permission("route:write")
-
-
-def _tenant_id(request: Request) -> UUID:
-    raw = getattr(request.state, "tenant_id", None)
-    if not raw:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
-    return raw if isinstance(raw, UUID) else UUID(str(raw))
-
-
-def _user_id(request: Request) -> UUID | None:
-    raw = getattr(request.state, "user_id", None)
-    if not raw:
-        return None
-    return raw if isinstance(raw, UUID) else UUID(str(raw))
 
 
 def create_dispatch_router(*, service_provider) -> APIRouter:

--- a/src/office_hero/api/routes/jobs.py
+++ b/src/office_hero/api/routes/jobs.py
@@ -23,6 +23,8 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, sta
 
 from office_hero.api.deps import require_permission, require_role
 from office_hero.api.limiter import limiter
+from office_hero.api.request_context import require_tenant_id as _tenant_id
+from office_hero.api.request_context import require_user_id as _user_id
 from office_hero.api.schemas.job import (
     JobCancelRequest,
     JobCompleteRequest,
@@ -60,22 +62,6 @@ _FIELD_ROLES = [
     Role.OperatorStaff,
 ]
 require_field_role = require_role(_FIELD_ROLES)
-
-
-def _tenant_id(request: Request) -> UUID:
-    """Extract tenant_id from request.state; raise 401 if missing."""
-    raw = getattr(request.state, "tenant_id", None)
-    if not raw:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
-    return raw if isinstance(raw, UUID) else UUID(str(raw))
-
-
-def _user_id(request: Request) -> UUID:
-    """Extract user_id from request.state for audit attribution."""
-    raw = getattr(request.state, "user_id", None)
-    if not raw:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
-    return raw if isinstance(raw, UUID) else UUID(str(raw))
 
 
 def create_job_router(*, service_provider) -> APIRouter:

--- a/src/office_hero/api/routes/locations.py
+++ b/src/office_hero/api/routes/locations.py
@@ -9,6 +9,8 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Request, status
 
 from office_hero.api.deps import require_permission, require_role
 from office_hero.api.limiter import limiter
+from office_hero.api.request_context import require_tenant_id as _tenant_id
+from office_hero.api.request_context import require_user_id as _user_id
 from office_hero.api.schemas.location import (
     LocationCoordinatesSet,
     LocationCreate,
@@ -30,22 +32,6 @@ require_customers_read = require_permission("customers:read")
 require_customers_write = require_permission("customers:write")
 require_dispatch_or_admin = require_role([Role.Dispatcher, Role.TenantAdmin, Role.Operator])
 require_archive_role = require_role([Role.TenantAdmin, Role.Operator, Role.OperatorStaff])
-
-
-def _tenant_id(request: Request) -> UUID:
-    """Extract tenant_id from request.state; raise 401 if missing."""
-    raw = getattr(request.state, "tenant_id", None)
-    if not raw:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
-    return raw if isinstance(raw, UUID) else UUID(str(raw))
-
-
-def _user_id(request: Request) -> UUID:
-    """Extract user_id from request.state for audit attribution."""
-    raw = getattr(request.state, "user_id", None)
-    if not raw:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
-    return raw if isinstance(raw, UUID) else UUID(str(raw))
 
 
 def create_location_router(*, service_provider) -> APIRouter:

--- a/src/office_hero/api/routes/routes.py
+++ b/src/office_hero/api/routes/routes.py
@@ -10,6 +10,8 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, sta
 
 from office_hero.api.deps import require_permission
 from office_hero.api.limiter import limiter
+from office_hero.api.request_context import require_tenant_id as _tenant_id
+from office_hero.api.request_context import require_user_id as _user_id
 from office_hero.api.schemas.route import (
     DispatchCommitRequest,
     RouteCancelRequest,
@@ -30,20 +32,6 @@ from office_hero.core.exceptions import (
 from office_hero.core.logging import get_logger
 
 log = get_logger(__name__)
-
-
-def _tenant_id(request: Request) -> UUID:
-    raw = getattr(request.state, "tenant_id", None)
-    if not raw:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
-    return raw if isinstance(raw, UUID) else UUID(str(raw))
-
-
-def _user_id(request: Request) -> UUID:
-    raw = getattr(request.state, "user_id", None)
-    if not raw:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
-    return raw if isinstance(raw, UUID) else UUID(str(raw))
 
 
 def create_routes_router(*, service_provider, repo_provider) -> APIRouter:

--- a/src/office_hero/api/routes/schedule_options.py
+++ b/src/office_hero/api/routes/schedule_options.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Request, status
 
 from office_hero.api.deps import require_permission
 from office_hero.api.limiter import limiter
+from office_hero.api.request_context import require_tenant_id as _tenant_id
 from office_hero.api.schemas.schedule_option import (
     ScheduleOptionItem,
     ScheduleOptionRequest,
@@ -21,13 +22,6 @@ log = get_logger(__name__)
 
 require_job_read = require_permission("job:read")
 require_vehicle_read = require_permission("vehicle:read")
-
-
-def _tenant_id(request: Request) -> UUID:
-    raw = getattr(request.state, "tenant_id", None)
-    if not raw:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
-    return raw if isinstance(raw, UUID) else UUID(str(raw))
 
 
 def create_schedule_options_router(*, service_provider) -> APIRouter:

--- a/src/office_hero/api/routes/tech.py
+++ b/src/office_hero/api/routes/tech.py
@@ -13,6 +13,8 @@ from pydantic import BaseModel
 
 from office_hero.api.deps import require_permission
 from office_hero.api.limiter import limiter
+from office_hero.api.request_context import require_tenant_id as _tenant_id
+from office_hero.api.request_context import require_user_id as _user_id
 from office_hero.core.logging import get_logger
 
 log = get_logger(__name__)
@@ -22,20 +24,6 @@ class MyCrewTodayResponse(BaseModel):
     crew_id: UUID
     vehicle_id: UUID
     work_date: date
-
-
-def _tenant_id(request: Request) -> UUID:
-    raw = getattr(request.state, "tenant_id", None)
-    if not raw:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
-    return raw if isinstance(raw, UUID) else UUID(str(raw))
-
-
-def _user_id(request: Request) -> UUID:
-    raw = getattr(request.state, "user_id", None)
-    if not raw:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
-    return raw if isinstance(raw, UUID) else UUID(str(raw))
 
 
 def create_tech_router(*, crew_service_provider) -> APIRouter:

--- a/src/office_hero/api/routes/vehicle_crews.py
+++ b/src/office_hero/api/routes/vehicle_crews.py
@@ -15,6 +15,8 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, sta
 
 from office_hero.api.deps import require_role
 from office_hero.api.limiter import limiter
+from office_hero.api.request_context import require_tenant_id as _tenant_id
+from office_hero.api.request_context import require_user_id as _user_id
 from office_hero.api.schemas.vehicle_crew import (
     CrewConflictRead,
     CrewMemberRead,
@@ -55,20 +57,6 @@ _CREW_CONFLICT_ROLES = [Role.Dispatcher, Role.TenantAdmin, Role.Operator, Role.O
 require_crew_write = require_role(_CREW_WRITE_ROLES)
 require_crew_read = require_role(_CREW_READ_ROLES)
 require_crew_conflict_read = require_role(_CREW_CONFLICT_ROLES)
-
-
-def _tenant_id(request: Request) -> UUID:
-    raw = getattr(request.state, "tenant_id", None)
-    if not raw:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
-    return raw if isinstance(raw, UUID) else UUID(str(raw))
-
-
-def _user_id(request: Request) -> UUID:
-    raw = getattr(request.state, "user_id", None)
-    if not raw:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
-    return raw if isinstance(raw, UUID) else UUID(str(raw))
 
 
 def _role(request: Request) -> str:

--- a/src/office_hero/api/routes/vehicle_location.py
+++ b/src/office_hero/api/routes/vehicle_location.py
@@ -9,18 +9,12 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Request, status
 
 from office_hero.api.deps import require_permission
 from office_hero.api.limiter import limiter
+from office_hero.api.request_context import require_tenant_id as _tenant_id
 from office_hero.api.schemas.vehicle_location import (
     VehicleLocationRequest,
     VehicleLocationResponse,
 )
 from office_hero.core.exceptions import VehicleNotFoundError
-
-
-def _tenant_id(request: Request) -> UUID:
-    raw = getattr(request.state, "tenant_id", None)
-    if not raw:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
-    return raw if isinstance(raw, UUID) else UUID(str(raw))
 
 
 def create_vehicle_location_router(*, service_provider) -> APIRouter:

--- a/src/office_hero/api/routes/vehicles.py
+++ b/src/office_hero/api/routes/vehicles.py
@@ -13,6 +13,8 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, sta
 
 from office_hero.api.deps import require_permission, require_role
 from office_hero.api.limiter import limiter
+from office_hero.api.request_context import require_tenant_id as _tenant_id
+from office_hero.api.request_context import require_user_id as _user_id
 from office_hero.api.schemas.vehicle import (
     VehicleCreate,
     VehicleList,
@@ -31,20 +33,6 @@ log = get_logger(__name__)
 
 require_vehicles_read = require_permission("vehicles:read")
 require_vehicles_write = require_role([Role.TenantAdmin, Role.Operator, Role.OperatorStaff])
-
-
-def _tenant_id(request: Request) -> UUID:
-    raw = getattr(request.state, "tenant_id", None)
-    if not raw:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
-    return raw if isinstance(raw, UUID) else UUID(str(raw))
-
-
-def _user_id(request: Request) -> UUID:
-    raw = getattr(request.state, "user_id", None)
-    if not raw:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
-    return raw if isinstance(raw, UUID) else UUID(str(raw))
 
 
 def create_vehicle_router(*, service_provider) -> APIRouter:

--- a/src/office_hero/repositories/job_repository.py
+++ b/src/office_hero/repositories/job_repository.py
@@ -46,6 +46,8 @@ class JobRepositoryProtocol(Protocol):
 
     async def get_by_id(self, job_id: UUID, tenant_id: UUID) -> Job | None: ...
 
+    async def bulk_get_by_ids(self, job_ids: list[UUID], tenant_id: UUID) -> list[Job]: ...
+
     async def list(
         self,
         tenant_id: UUID,
@@ -137,6 +139,14 @@ class JobRepository:
         stmt = select(Job).where(Job.id == job_id, Job.tenant_id == tenant_id)
         result = await self.session.execute(stmt)
         return result.scalars().first()
+
+    async def bulk_get_by_ids(self, job_ids: list[UUID], tenant_id: UUID) -> list[Job]:
+        """Fetch many jobs by id within ``tenant_id`` in a single query."""
+        if not job_ids:
+            return []
+        stmt = select(Job).where(Job.id.in_(job_ids), Job.tenant_id == tenant_id)
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())
 
     async def list(
         self,
@@ -353,6 +363,15 @@ class InMemoryJobRepository:
         if row is None or row["tenant_id"] != tenant_id:
             return None
         return self._row_to_job(row)
+
+    async def bulk_get_by_ids(self, job_ids: list[UUID], tenant_id: UUID) -> list[Job]:
+        """Return all jobs in this tenant whose id is in ``job_ids``."""
+        wanted = set(job_ids)
+        return [
+            self._row_to_job(r)
+            for r in self._rows.values()
+            if r["tenant_id"] == tenant_id and r["id"] in wanted
+        ]
 
     async def list(
         self,

--- a/src/office_hero/services/dispatch_service.py
+++ b/src/office_hero/services/dispatch_service.py
@@ -223,17 +223,22 @@ class DispatchService:
             raise InvalidRouteTransitionError(str(from_status), str(RouteStatus.CANCELLED))
 
         stops = await self._stop_repo.get_for_route(tenant_id, route_id)
+        non_terminal = [s for s in stops if not is_terminal_stop(RouteStopStatus(s.status))]
+        # Fetch the affected jobs in one query rather than one-per-stop (N+1).
+        jobs_by_id = {
+            j.id: j
+            for j in await self._job_repo.bulk_get_by_ids(
+                [s.job_id for s in non_terminal], tenant_id
+            )
+        }
         affected = 0
-        for stop in stops:
-            if not is_terminal_stop(RouteStopStatus(stop.status)):
-                await self._stop_repo.update_status(stop.id, tenant_id, RouteStopStatus.SKIPPED)
-                # Return scheduled jobs to pending
-                job = await self._job_repo.get_by_id(stop.job_id, tenant_id)
-                if job is not None and job.status == JobStatus.SCHEDULED:
-                    await self._job_repo.update_fields(
-                        stop.job_id, tenant_id, status=JobStatus.PENDING
-                    )
-                affected += 1
+        for stop in non_terminal:
+            await self._stop_repo.update_status(stop.id, tenant_id, RouteStopStatus.SKIPPED)
+            # Return scheduled jobs to pending
+            job = jobs_by_id.get(stop.job_id)
+            if job is not None and job.status == JobStatus.SCHEDULED:
+                await self._job_repo.update_fields(stop.job_id, tenant_id, status=JobStatus.PENDING)
+            affected += 1
 
         route = await self._route_repo.update_status(
             route_id,
@@ -425,9 +430,11 @@ class DispatchService:
         if errors:
             raise ManualSequenceInvalidError("Manual sequence failed validation", errors=errors)
 
-        # Validate each job exists and is not terminal
+        # Validate each job exists and is not terminal (bulk-fetch, then check
+        # in sequence order to preserve error ordering).
+        jobs_by_id = {j.id: j for j in await self._job_repo.bulk_get_by_ids(sequence, tenant_id)}
         for jid in sequence:
-            job = await self._job_repo.get_by_id(jid, tenant_id)
+            job = jobs_by_id.get(jid)
             if job is None:
                 errors.append(f"job {jid} not found in tenant")
             elif job.status in (JobStatus.COMPLETE, JobStatus.CANCELLED):


### PR DESCRIPTION
## Summary

Second optimization pass — five audit-confirmed, adversarially-verified safe wins (lessons from pass 1 applied: no parallel file-editing agents; all changes applied + verified in the main loop).

### Duplication
- **`src/office_hero/api/request_context.py`** — single home for `require_tenant_id` / `require_user_id` (raise 401) and `optional_user_id` (None). Replaces ~20 identical local `_tenant_id`/`_user_id` helpers across **11 route modules** (dispatch keeps the optional-user variant; schedule_options/vehicle_location are tenant-only). *Verified: 72 route-handler tests across all variants.*
- **`apps/admin-web/src/components/StatusBadges.tsx`** — `JobStatusBadge`/`ContractStatusBadge`/`RouteStatusBadge` replace three near-identical local `StatusBadge`+COLORS+LABELS blocks in JobsPage/ContractsPage/RoutesPage (exact labels/colors preserved). *Lint + build green, 302.4 kB.*

### Performance
- **N+1 fix**: `cancel_route` and `_resolve_manual_mode` fetched each job in a loop; added `JobRepository.bulk_get_by_ids` (SQL `WHERE id IN` + in-memory impl) and fetch once into a dict. Manual-mode error ordering preserved. *Verified: 44 dispatch/routes/golden-path/job tests.*
- **Migration 0014**: composite `(tenant_id, vehicle_id, work_date)` on vehicle_crews (the crew lookup on every dispatch/reassign/emergency) and `(tenant_id, status, next_due)` on contracts (the whole `list_due` generation-pass query in one scan).

### Notes
- The audit also surfaced findings I declined (kept conservative). The dev machine remained CPU-degraded, so local runs were slow but the targeted suites above passed; CI's clean runners are the authoritative verifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)