### PR TITLE
feat(slice-032): live route events via SSE

### DIFF
--- a/apps/admin-web/src/hooks/useRouteEvents.ts
+++ b/apps/admin-web/src/hooks/useRouteEvents.ts
@@ -23,8 +23,6 @@ export function useRouteEvents(
   routeId: string | null,
   onEvent: (event: RouteEvent) => void,
 ): void {
-  // Wrap onEvent in useCallback at the call site, or stabilise here with a ref
-  // to avoid re-subscribing on every render.
   const stableOnEvent = useCallback(onEvent, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
@@ -41,7 +39,6 @@ export function useRouteEvents(
       }
     };
 
-    // onerror: browser will auto-reconnect with exponential backoff
     es.onerror = () => {};
 
     return () => {

--- a/apps/admin-web/src/pages/RoutesPage.tsx
+++ b/apps/admin-web/src/pages/RoutesPage.tsx
@@ -6,12 +6,14 @@ import {
   type RouteStopStatus,
   type VehicleLocationResponse,
   cancelRouteApi,
+  getRouteApi,
   getVehicleLatestLocationApi,
   listRoutesApi,
   reassignRouteApi,
   resequenceRouteApi,
   startRouteApi,
 } from '../api';
+import { useRouteEvents } from '../hooks/useRouteEvents';
 import { Alert } from '../components/ui/Alert';
 import { ErrorBanner } from '../components/ui/ErrorBanner';
 import { useAutoRecover } from '../hooks/useAutoRecover';
@@ -254,6 +256,14 @@ function RouteCard({
 
   // Live GPS position — polls every 30 s while route is in_progress.
   const location = useVehicleLocation(route.vehicle_id, route.status === 'in_progress');
+
+  // Live route events via SSE — re-fetch on any state change from another client.
+  useRouteEvents(
+    route.status === 'in_progress' ? route.id : null,
+    useCallback(() => {
+      getRouteApi(route.id).then(onUpdated).catch(() => {});
+    }, [route.id, onUpdated]),
+  );
 
   const stops = [...route.stops].sort((a, b) => a.sequence_index - b.sequence_index);
   const displayedJobIds = order ?? stops.map((s) => s.job_id);

--- a/src/office_hero/api/routes/routes.py
+++ b/src/office_hero/api/routes/routes.py
@@ -7,6 +7,7 @@ from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
+from fastapi.responses import StreamingResponse
 
 from office_hero.api.deps import require_permission
 from office_hero.api.limiter import limiter
@@ -30,6 +31,7 @@ from office_hero.core.exceptions import (
     VehicleNotFoundError,
 )
 from office_hero.core.logging import get_logger
+from office_hero.core.route_events import publish, subscribe
 
 log = get_logger(__name__)
 
@@ -82,6 +84,36 @@ def create_routes_router(*, service_provider, repo_provider) -> APIRouter:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Route not found")
 
         return route
+
+    @router.get(
+        "/{route_id}/events",
+        summary="SSE stream of route state-change events",
+        description=(
+            "Server-Sent Events stream. Emits JSON on route_started, route_cancelled, "
+            "stop_arrived, stop_completed, stop_skipped. The browser EventSource API "
+            "reconnects automatically. route_id UUIDs are non-guessable (MVP: no auth "
+            "check; add JWT query-param validation in a future slice)."
+        ),
+        response_class=StreamingResponse,
+    )
+    async def route_event_stream(
+        route_id: Annotated[UUID, Path()],
+    ) -> StreamingResponse:
+        """Stream route events to a connected admin-web client via SSE."""
+
+        async def gen():
+            async for msg in subscribe(f"route:{route_id}"):
+                yield f"data: {msg}\n\n"
+
+        return StreamingResponse(
+            gen(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+                "Connection": "keep-alive",
+            },
+        )
 
     @router.post(
         "", response_model=RouteRead, dependencies=[Depends(require_permission("route:write"))]
@@ -216,6 +248,7 @@ def create_routes_router(*, service_provider, repo_provider) -> APIRouter:
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
             ) from exc
 
+        await publish(f"route:{route_id}", {"type": "route_started", "route_id": str(route_id)})
         return route
 
     @router.post(
@@ -243,6 +276,10 @@ def create_routes_router(*, service_provider, repo_provider) -> APIRouter:
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
             ) from exc
 
+        await publish(
+            f"route:{route_id}",
+            {"type": "route_cancelled", "route_id": str(route_id), "reason": body.reason},
+        )
         return route
 
     @router.post(
@@ -266,6 +303,11 @@ def create_routes_router(*, service_provider, repo_provider) -> APIRouter:
         route = await repo.get_by_id(route_id, tenant_id)
         if not route:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Route not found")
+
+        await publish(
+            f"route:{route_id}",
+            {"type": "stop_arrived", "route_id": str(route_id), "stop_id": str(stop_id)},
+        )
         return route
 
     @router.post(
@@ -289,6 +331,11 @@ def create_routes_router(*, service_provider, repo_provider) -> APIRouter:
         route = await repo.get_by_id(route_id, tenant_id)
         if not route:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Route not found")
+
+        await publish(
+            f"route:{route_id}",
+            {"type": "stop_completed", "route_id": str(route_id), "stop_id": str(stop_id)},
+        )
         return route
 
     @router.post(
@@ -313,6 +360,16 @@ def create_routes_router(*, service_provider, repo_provider) -> APIRouter:
         route = await repo.get_by_id(route_id, tenant_id)
         if not route:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Route not found")
+
+        await publish(
+            f"route:{route_id}",
+            {
+                "type": "stop_skipped",
+                "route_id": str(route_id),
+                "stop_id": str(stop_id),
+                "reason": body.reason,
+            },
+        )
         return route
 
     return router

--- a/src/office_hero/core/route_events.py
+++ b/src/office_hero/core/route_events.py
@@ -1,0 +1,44 @@
+"""Async pub/sub hub for route state-change events.
+
+Admin-web clients subscribe to a route's event stream via SSE
+(GET /routes/{id}/events). Route API handlers publish here after each
+state-changing operation so connected dispatchers see updates instantly.
+
+Scalability note: subscriptions live in process memory, so this works
+correctly on a single Fly.io instance. Replace `_subscribers` with a
+Redis pub/sub backend if the deployment ever scales horizontally.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from collections import defaultdict
+from typing import Any, AsyncGenerator
+
+_subscribers: defaultdict[str, list[asyncio.Queue[str]]] = defaultdict(list)
+
+
+async def subscribe(topic: str) -> AsyncGenerator[str, None]:
+    """Yield JSON-encoded event strings until the caller disconnects."""
+    q: asyncio.Queue[str] = asyncio.Queue()
+    _subscribers[topic].append(q)
+    try:
+        while True:
+            yield await q.get()
+    finally:
+        try:
+            _subscribers[topic].remove(q)
+        except ValueError:
+            pass
+
+
+async def publish(topic: str, payload: dict[str, Any]) -> None:
+    """Broadcast a payload to all current subscribers of *topic*."""
+    message = json.dumps(payload)
+    for q in list(_subscribers.get(topic, [])):
+        await q.put(message)
+
+
+def subscriber_count(topic: str) -> int:
+    """Return the number of active SSE subscribers for *topic* (test helper)."""
+    return len(_subscribers.get(topic, []))

--- a/tests/test_route_events.py
+++ b/tests/test_route_events.py
@@ -1,0 +1,121 @@
+"""Unit tests for the route_events pub/sub hub."""
+
+import asyncio
+import json
+
+import pytest
+
+from office_hero.core.route_events import _subscribers, publish, subscribe, subscriber_count
+
+
+@pytest.fixture(autouse=True)
+def clear_route_event_state():
+    """Reset global subscriber dict before/after each test to prevent cross-test leakage."""
+    _subscribers.clear()
+    yield
+    _subscribers.clear()
+
+
+@pytest.mark.asyncio
+async def test_publish_reaches_subscriber() -> None:
+    topic = "route:aaaaaaaa-0000-0000-0000-000000000001"
+    received: list[dict] = []
+
+    async def consumer() -> None:
+        async for msg in subscribe(topic):
+            received.append(json.loads(msg))
+            return  # consume one message then exit
+
+    task = asyncio.create_task(consumer())
+    await asyncio.sleep(0)  # yield so consumer can register
+
+    await publish(topic, {"type": "stop_arrived", "stop_id": "s1"})
+    await task
+
+    assert received == [{"type": "stop_arrived", "stop_id": "s1"}]
+
+
+@pytest.mark.asyncio
+async def test_publish_to_multiple_subscribers() -> None:
+    topic = "route:bbbbbbbb-0000-0000-0000-000000000002"
+    received_a: list[dict] = []
+    received_b: list[dict] = []
+
+    async def consumer_a() -> None:
+        async for msg in subscribe(topic):
+            received_a.append(json.loads(msg))
+            return
+
+    async def consumer_b() -> None:
+        async for msg in subscribe(topic):
+            received_b.append(json.loads(msg))
+            return
+
+    ta = asyncio.create_task(consumer_a())
+    tb = asyncio.create_task(consumer_b())
+    await asyncio.sleep(0)
+
+    await publish(topic, {"type": "route_started"})
+    await ta
+    await tb
+
+    assert received_a == [{"type": "route_started"}]
+    assert received_b == [{"type": "route_started"}]
+
+
+@pytest.mark.asyncio
+async def test_publish_to_unknown_topic_is_noop() -> None:
+    await publish("route:nonexistent", {"type": "test"})  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_subscriber_count() -> None:
+    topic = "route:cccccccc-0000-0000-0000-000000000003"
+    assert subscriber_count(topic) == 0
+
+    received: asyncio.Event = asyncio.Event()
+
+    async def consumer() -> None:
+        async for _msg in subscribe(topic):
+            received.set()
+            # Stay in the loop so the generator remains open until we cancel.
+            # This mirrors the real SSE use-case and lets cancel() propagate
+            # CancelledError directly into the generator's finally block.
+
+    task = asyncio.create_task(consumer())
+    await asyncio.sleep(0)
+
+    assert subscriber_count(topic) == 1
+
+    await publish(topic, {"type": "ping"})
+    await received.wait()
+    # Consumer re-enters the generator after received.set(), suspending at
+    # yield await q.get() before the event loop returns here.
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    assert subscriber_count(topic) == 0
+
+
+@pytest.mark.asyncio
+async def test_subscriber_removed_on_cancellation() -> None:
+    topic = "route:dddddddd-0000-0000-0000-000000000004"
+
+    async def consumer() -> None:
+        async for _msg in subscribe(topic):
+            pass  # pragma: no cover
+
+    task = asyncio.create_task(consumer())
+    await asyncio.sleep(0)
+    assert subscriber_count(topic) == 1
+
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    assert subscriber_count(topic) == 0


### PR DESCRIPTION
## Summary

- **Backend**: `GET /routes/{id}/events` SSE endpoint backed by an in-process asyncio pub/sub hub (`route_events.py`). Publishes on `start_route`, `cancel_route`, `mark_stop_arrived`, `mark_stop_complete`, `skip_stop`.
- **Frontend**: `useRouteEvents(routeId, onEvent)` React hook using the `EventSource` API. `RouteCard` subscribes when `route.status === 'in_progress'`; on any event, re-fetches the full route via `getRouteApi` and calls `onUpdated`.
- **Tests**: 5 async pytest tests for the pub/sub hub covering subscribe, multi-subscriber fan-out, unknown-topic noop, subscriber count, and cancellation cleanup.

## Design notes

- SSE chosen over WebSocket: route events are server→browser only; SSE reconnects automatically; no upgrade handshake needed for Fly.io proxy.
- Auth deferred: UUID non-guessability is the MVP gate; JWT query-param validation planned for a follow-up slice.
- In-process hub: single Fly.io instance; no Redis needed.
- Re-fetch on event rather than patch: route payload is small and this is always correct.

## Test plan

- [x] `python -m pytest tests/test_route_events.py` — 5/5 pass
- [x] Full backend suite `python -m pytest --no-cov` — 569 passed, 0 failed
- [x] `pnpm exec tsc --noEmit` — TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)